### PR TITLE
chore: MARKET_NOW env override for manual UI testing

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, time as dt_time, timedelta
 from functools import lru_cache
 import pytz
@@ -23,8 +24,17 @@ def is_trading_day(date):
     return not schedule.empty
 
 def get_nyse_datetime():
-    """Get current datetime in NYSE timezone"""
-    return datetime.now(pytz.UTC).astimezone(NYSE_TIMEZONE) #- timedelta(hours=13) #for testing
+    """Current datetime in NYSE timezone.
+
+    Manual/QA override: set env var MARKET_NOW to an ISO datetime (e.g.
+    "2026-05-25T10:00") to force the app to believe it is that NYSE-local
+    instant. Used to eyeball market-status states in the UI without waiting for
+    a real weekend/holiday. Unset in production -> real wall clock.
+    """
+    override = os.environ.get("MARKET_NOW")
+    if override:
+        return NYSE_TIMEZONE.localize(datetime.fromisoformat(override))
+    return datetime.now(pytz.UTC).astimezone(NYSE_TIMEZONE)
 
 def get_nyse_date():
     """Get current date in NYSE timezone"""


### PR DESCRIPTION
## What
Adds an optional `MARKET_NOW` environment override to `get_nyse_datetime()`.

## Why
Lets us force the app into any market-status state (weekend, holiday, pre-bell, open, after-close) to visually verify the §0 fix in the rendered UI, without waiting for a real Saturday or holiday.

## Usage
```powershell
$env:MARKET_NOW="2026-06-13T12:00"; streamlit run stock_predictors.py   # Sat noon -> Closed (the bug case)
$env:MARKET_NOW="2026-06-15T11:00"; streamlit run stock_predictors.py   # Mon 11:00 -> Open
```
Unset -> real wall clock. Unit tests unaffected (they monkeypatch the function directly).

## Test
`pytest tests/ -q` -> 18 passed (override not set during tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)