### PR TITLE
feat(ui): single status-driven header (§1)

### DIFF
--- a/display_market_status.py
+++ b/display_market_status.py
@@ -58,11 +58,13 @@ def generate_next_day_header(next_date_str):
     return f"Predictions for {next_date_str}"
 
 
-def display_market_status(last_available_date=None):
+def display_market_status(last_available_date):
     """
     Display the single status-driven header.
     Args:
         last_available_date: date of the last completed session (data.index[-1]).
+            Required — the caller only invokes this once it has a real session
+            date, so there is no meaningful None default.
     """
     status = market_status()
     today_is_trading_day = is_trading_day(get_nyse_date())

--- a/display_market_status.py
+++ b/display_market_status.py
@@ -1,58 +1,56 @@
 import streamlit as st
-from utils import get_nyse_datetime, market_status
+from utils import market_status
 
-def generate_market_status_header(date_str):
-    """Generate the header with the current date."""
-    return f"<h2 style='text-align: center; margin-bottom: 0;'>{date_str}</h2>"
+# Inline status icon + title. Title is driven by market_status() so the single
+# header replaces the old centered date <h2> + the separate "Today's Close
+# Predictions" subheader (plan §1). User only ever distinguishes Open vs Closed.
+_STATUS = {
+    "BEFORE_MARKET_OPEN": {"icon": "⏳", "title": "Predictions for {date}"},
+    "MARKET_OPEN":        {"icon": "🔔", "title": "Live — Last Traded"},
+    "AFTER_MARKET_CLOSE": {"icon": "🔴", "title": "Today's Close Predictions"},
+}
 
-def generate_market_status_message(status, last_date_str, time_str):
-    """Generate the market status message based on the current market status."""
-    status_messages = {
-        "BEFORE_MARKET_OPEN": {
-            "icon": "⏳",
-            "title": "Market hasn't opened yet",
-            "subtitle": f"Predicted closing prices are for {last_date_str} based on the latest available data"
-        },
-        "MARKET_OPEN": {
-            "icon": "🔔",
-            "title": "Market is Open",
-            "subtitle": f"Predicted closing price for {last_date_str} based on current time: {time_str}"
-        },
-        "AFTER_MARKET_CLOSE": {
-            "icon": "🔴",
-            "title": "Market is Closed",
-            "subtitle": f"Predicted closing price for {last_date_str}. Today's closing prices are final."
-        }
-    }
-    
-    # Raise an error if the status is not found, which helps catch potential issues
-    if status not in status_messages:
+
+def generate_market_status_header(status, last_date_str):
+    """Single status-driven header (icon + title, left-aligned) with an optional
+    session-date subtitle.
+
+    Subtitle binary on market status:
+      - MARKET_OPEN          → no subtitle (data is today's, self-explanatory).
+      - AFTER_MARKET_CLOSE   → "Last traded session — <date>".
+      - BEFORE_MARKET_OPEN   → no subtitle; the title already names the session
+                               date, so a date subtitle would just duplicate it.
+    """
+    if status not in _STATUS:
         raise ValueError(f"Unknown market status: {status}")
-    
-    message = status_messages[status]
-    
-    return f"""<div style='text-align: center; margin-top: -10px;'>
-        <h3 style='margin-bottom: 0;'>{message['icon']} {message['title']}</h3>
-        <div style='font-size: 10pt; margin-top: -10px;'>{message['subtitle']}</div>
+
+    icon = _STATUS[status]["icon"]
+    title = _STATUS[status]["title"].format(date=last_date_str)
+
+    subtitle_html = ""
+    if status == "AFTER_MARKET_CLOSE":
+        subtitle_html = (
+            "<div style='font-size: 10pt; color: #64748b; margin-top: 2px;'>"
+            f"Last traded session — {last_date_str}</div>"
+        )
+
+    return f"""<div style='text-align: left; margin-bottom: 8px;'>
+        <h3 style='margin: 0;'>{icon} {title}</h3>
+        {subtitle_html}
     </div>"""
+
 
 def display_market_status(last_available_date=None):
     """
-    Display market status with icon and description.
+    Display the single status-driven header.
     Args:
-        last_available_date: Last available trading date (for BEFORE_MARKET_OPEN state)
+        last_available_date: date of the last completed session (data.index[-1]).
     """
-    # Get current time in Eastern Time
-    current_time = get_nyse_datetime()
     status = market_status()
-    
-    # Format and display current date
-    date_str = current_time.strftime('%A, %B %d, %Y')
-    st.markdown(generate_market_status_header(date_str), unsafe_allow_html=True)
-
     last_date_str = last_available_date.strftime('%A, %B %d')
-    time_str = current_time.strftime('%I:%M %p EST')  # Add EST to the time
 
-    st.markdown(generate_market_status_message(status, last_date_str, time_str), unsafe_allow_html=True)
-    
+    st.markdown(
+        generate_market_status_header(status, last_date_str),
+        unsafe_allow_html=True,
+    )
     st.markdown("---")  # Add a separator line

--- a/display_market_status.py
+++ b/display_market_status.py
@@ -1,43 +1,50 @@
 import streamlit as st
-from utils import market_status
-
-# Inline status icon + title. Title is driven by market_status() so the single
-# header replaces the old centered date <h2> + the separate "Today's Close
-# Predictions" subheader (plan §1). User only ever distinguishes Open vs Closed.
-_STATUS = {
-    "BEFORE_MARKET_OPEN": {"icon": "⏳", "title": "Predictions for {date}"},
-    "MARKET_OPEN":        {"icon": "🔔", "title": "Live — Last Traded"},
-    "AFTER_MARKET_CLOSE": {"icon": "🔴", "title": "Today's Close Predictions"},
-}
+from utils import market_status, is_trading_day, get_nyse_date
 
 
-def generate_market_status_header(status, last_date_str):
-    """Single status-driven header (icon + title, left-aligned) with an optional
-    session-date subtitle.
+def generate_market_status_header(status, last_date_str, today_is_trading_day=True):
+    """Single status-driven header (icon + title, left-aligned).
 
-    Subtitle binary on market status:
-      - MARKET_OPEN          → no subtitle (data is today's, self-explanatory).
-      - AFTER_MARKET_CLOSE   → "Last traded session — <date>".
-      - BEFORE_MARKET_OPEN   → no subtitle; the title already names the session
-                               date, so a date subtitle would just duplicate it.
+    The title carries everything inline (no separate subtitle). `last_date_str`
+    is the last completed session's date (data.index[-1]).
+
+    Title by state:
+      - BEFORE_MARKET_OPEN (trading day, pre-bell):
+            "Market Closed - Displaying Predictions for <last traded date>"
+      - MARKET_OPEN:
+            "Live — Last Traded"
+      - AFTER_MARKET_CLOSE on a trading day (today's close is final):
+            "Today's Close Predictions and Actuals"
+      - AFTER_MARKET_CLOSE on a weekend/holiday (today never traded):
+            "Market Closed Weekend/Holiday - Displaying Predictions for
+             <last traded date>"
+
+    `today_is_trading_day` only matters for AFTER_MARKET_CLOSE — it splits the
+    trading-day-after-close case from the weekend/holiday case, which
+    market_status() collapses into one status.
     """
-    if status not in _STATUS:
+    if status == "MARKET_OPEN":
+        icon, title = "🔔", "Live — Last Traded"
+    elif status == "BEFORE_MARKET_OPEN":
+        icon = "🔴"
+        title = f"Market Closed - Displaying Predictions for {last_date_str}"
+    elif status == "AFTER_MARKET_CLOSE":
+        icon = "🔴"
+        if today_is_trading_day:
+            title = "Today's Close Predictions and Actuals"
+        else:
+            title = (
+                "Market Closed Weekend/Holiday - Displaying Predictions for "
+                f"{last_date_str}"
+            )
+    else:
         raise ValueError(f"Unknown market status: {status}")
 
-    icon = _STATUS[status]["icon"]
-    title = _STATUS[status]["title"].format(date=last_date_str)
-
-    subtitle_html = ""
-    if status == "AFTER_MARKET_CLOSE":
-        subtitle_html = (
-            "<div style='font-size: 10pt; color: #64748b; margin-top: 2px;'>"
-            f"Last traded session — {last_date_str}</div>"
-        )
-
-    return f"""<div style='text-align: left; margin-bottom: 8px;'>
-        <h3 style='margin: 0;'>{icon} {title}</h3>
-        {subtitle_html}
-    </div>"""
+    return (
+        "<div style='text-align: left; margin-bottom: 8px;'>"
+        f"<h3 style='margin: 0;'>{icon} {title}</h3>"
+        "</div>"
+    )
 
 
 def display_market_status(last_available_date=None):
@@ -47,10 +54,11 @@ def display_market_status(last_available_date=None):
         last_available_date: date of the last completed session (data.index[-1]).
     """
     status = market_status()
+    today_is_trading_day = is_trading_day(get_nyse_date())
     last_date_str = last_available_date.strftime('%A, %B %d')
 
     st.markdown(
-        generate_market_status_header(status, last_date_str),
+        generate_market_status_header(status, last_date_str, today_is_trading_day),
         unsafe_allow_html=True,
     )
     st.markdown("---")  # Add a separator line

--- a/display_market_status.py
+++ b/display_market_status.py
@@ -47,6 +47,17 @@ def generate_market_status_header(status, last_date_str, today_is_trading_day=Tr
     )
 
 
+def generate_next_day_header(next_date_str):
+    """Header for the forward next-day-close section.
+
+    Always forward-looking, so it never uses the "Displaying" cue (that cue is
+    reserved for the main header's past-session accuracy recaps). `next_date_str`
+    is the concrete next trading session (utils.next_trading_day of the last
+    completed session) — before the bell this is today.
+    """
+    return f"Predictions for {next_date_str}"
+
+
 def display_market_status(last_available_date=None):
     """
     Display the single status-driven header.

--- a/render_ui.py
+++ b/render_ui.py
@@ -55,7 +55,6 @@ def display_results(predictions):
             if len(ticker_data[ticker]) >= 2 and last_available_date is None:
                 last_available_date = ticker_data[ticker].index[-1].date()
                 display_market_status(last_available_date)
-                st.subheader("Today's Close Predictions")
 
         except Exception as e:
             st.error(f"Error in the downloading of current data for {ticker}: {str(e)}")

--- a/render_ui.py
+++ b/render_ui.py
@@ -10,8 +10,8 @@ from render_helpers import (
     search_and_add_ticker,
 )
 from rules import UI_RULES
-from display_market_status import display_market_status
-from utils import market_status
+from display_market_status import display_market_status, generate_next_day_header
+from utils import market_status, next_trading_day
 
 
 def enforce_max_tickers():
@@ -105,7 +105,13 @@ def display_results(predictions):
     # Display next day predictions if available
     if next_day_close_predictions:
         st.markdown("---")
-        st.subheader("Next Day's Close Predictions")
+        # Forward section: label with the concrete next trading session (the
+        # session after the last completed one). Before the bell this is today.
+        if last_available_date is not None:
+            next_session = next_trading_day(last_available_date)
+            st.subheader(generate_next_day_header(next_session.strftime('%A, %B %d')))
+        else:
+            st.subheader(generate_next_day_header("the next session"))
 
         # Process each ticker for next day's predictions
         for ticker, predictions in grouped_next_day_predictions.items():

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,9 +1,16 @@
 """Isolated tests for the single status-driven header (plan section 1).
 
 Smoke-tests the rendered HTML of generate_market_status_header() per market
-status. Locks: one left-aligned header, status-driven title, inline icon, and
-the subtitle binary (date shown only when Closed-after-close). Pure function,
-no Streamlit / no time dependence, so it is deterministic.
+state. Locks: one left-aligned header, status-driven title, inline icon, and
+the after-close trading-day vs weekend/holiday split. Pure function, no
+Streamlit / no time dependence, so it is deterministic.
+
+State → header copy:
+  BEFORE_MARKET_OPEN          → "Market Closed - Displaying Predictions for <date>"
+  MARKET_OPEN                 → "Live — Last Traded" (no date)
+  AFTER_MARKET_CLOSE, trading → "Today's Close Predictions and Actuals" (no date)
+  AFTER_MARKET_CLOSE, off-day → "Market Closed Weekend/Holiday - Displaying
+                                 Predictions for <date>"
 """
 import pytest
 
@@ -12,29 +19,35 @@ from display_market_status import generate_market_status_header
 DATE = "Friday, June 12"
 
 
-def test_before_open_title_names_session_date():
+def test_before_open_shows_last_traded_date():
     html = generate_market_status_header("BEFORE_MARKET_OPEN", DATE)
-    assert "⏳" in html
-    assert f"Predictions for {DATE}" in html
-    # title already carries the date → no duplicate subtitle date
-    assert "Last traded session" not in html
+    assert "🔴" in html
+    assert f"Market Closed - Displaying Predictions for {DATE}" in html
 
 
 def test_market_open_live_no_date():
     html = generate_market_status_header("MARKET_OPEN", DATE)
     assert "🔔" in html
     assert "Live — Last Traded" in html
-    # Open → no session-date subtitle
     assert DATE not in html
-    assert "Last traded session" not in html
 
 
-def test_after_close_title_and_date_subtitle():
-    html = generate_market_status_header("AFTER_MARKET_CLOSE", DATE)
+def test_after_close_trading_day_predictions_and_actuals():
+    html = generate_market_status_header(
+        "AFTER_MARKET_CLOSE", DATE, today_is_trading_day=True
+    )
     assert "🔴" in html
-    assert "Today's Close Predictions" in html
-    # Closed-after-close → date appears in the subtitle
-    assert f"Last traded session — {DATE}" in html
+    assert "Today's Close Predictions and Actuals" in html
+    # today's close is final → no last-traded date in the title
+    assert DATE not in html
+
+
+def test_after_close_weekend_holiday_shows_last_traded_date():
+    html = generate_market_status_header(
+        "AFTER_MARKET_CLOSE", DATE, today_is_trading_day=False
+    )
+    assert "🔴" in html
+    assert f"Market Closed Weekend/Holiday - Displaying Predictions for {DATE}" in html
 
 
 def test_header_is_left_aligned_single_block():

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -12,9 +12,12 @@ State → header copy:
   AFTER_MARKET_CLOSE, off-day → "Market Closed Weekend/Holiday - Displaying
                                  Predictions for <date>"
 """
+from datetime import date
+
 import pytest
 
-from display_market_status import generate_market_status_header
+from display_market_status import generate_market_status_header, generate_next_day_header
+from utils import next_trading_day
 
 DATE = "Friday, June 12"
 
@@ -69,3 +72,22 @@ def test_hardcoded_finality_string_removed():
 def test_unknown_status_raises():
     with pytest.raises(ValueError):
         generate_market_status_header("NONSENSE", DATE)
+
+
+# --- next-day (forward) section header --------------------------------------
+def test_next_day_header_is_forward_no_displaying_cue():
+    # forward section never uses the "Displaying" past-session cue
+    html = generate_next_day_header("Monday, June 15")
+    assert html == "Predictions for Monday, June 15"
+    assert "Displaying" not in html
+
+
+# --- next_trading_day: concrete target session (real XNYS calendar) ---------
+@pytest.mark.parametrize("last_session, expected, desc", [
+    (date(2026, 6, 12), date(2026, 6, 15), "Fri -> Mon (skip weekend) = today before open"),
+    (date(2026, 6, 15), date(2026, 6, 16), "Mon -> Tue (normal next session)"),
+    (date(2026, 5, 22), date(2026, 5, 26), "Fri before Memorial Day -> Tue (skip Mon holiday)"),
+    (date(2026, 7, 2),  date(2026, 7, 6),  "Thu -> Mon (skip Jul 3 holiday + weekend)"),
+])
+def test_next_trading_day(last_session, expected, desc):
+    assert next_trading_day(last_session) == expected, desc

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,0 +1,58 @@
+"""Isolated tests for the single status-driven header (plan section 1).
+
+Smoke-tests the rendered HTML of generate_market_status_header() per market
+status. Locks: one left-aligned header, status-driven title, inline icon, and
+the subtitle binary (date shown only when Closed-after-close). Pure function,
+no Streamlit / no time dependence, so it is deterministic.
+"""
+import pytest
+
+from display_market_status import generate_market_status_header
+
+DATE = "Friday, June 12"
+
+
+def test_before_open_title_names_session_date():
+    html = generate_market_status_header("BEFORE_MARKET_OPEN", DATE)
+    assert "⏳" in html
+    assert f"Predictions for {DATE}" in html
+    # title already carries the date → no duplicate subtitle date
+    assert "Last traded session" not in html
+
+
+def test_market_open_live_no_date():
+    html = generate_market_status_header("MARKET_OPEN", DATE)
+    assert "🔔" in html
+    assert "Live — Last Traded" in html
+    # Open → no session-date subtitle
+    assert DATE not in html
+    assert "Last traded session" not in html
+
+
+def test_after_close_title_and_date_subtitle():
+    html = generate_market_status_header("AFTER_MARKET_CLOSE", DATE)
+    assert "🔴" in html
+    assert "Today's Close Predictions" in html
+    # Closed-after-close → date appears in the subtitle
+    assert f"Last traded session — {DATE}" in html
+
+
+def test_header_is_left_aligned_single_block():
+    html = generate_market_status_header("AFTER_MARKET_CLOSE", DATE)
+    assert "text-align: left" in html
+    assert "text-align: center" not in html
+    # one header element, not a stacked date <h2> + <h3>
+    assert html.count("<h3") == 1
+    assert "<h2" not in html
+
+
+def test_hardcoded_finality_string_removed():
+    # the old "Today's closing prices are final." copy must be gone
+    for status in ("BEFORE_MARKET_OPEN", "MARKET_OPEN", "AFTER_MARKET_CLOSE"):
+        html = generate_market_status_header(status, DATE)
+        assert "are final" not in html
+
+
+def test_unknown_status_raises():
+    with pytest.raises(ValueError):
+        generate_market_status_header("NONSENSE", DATE)

--- a/utils.py
+++ b/utils.py
@@ -23,6 +23,22 @@ def is_trading_day(date):
     schedule = _NYSE_CALENDAR.schedule(start_date=date, end_date=date)
     return not schedule.empty
 
+@lru_cache(maxsize=8)
+def next_trading_day(date):
+    """Next NYSE trading day strictly after `date` (skips weekends/holidays).
+
+    Used to label the forward "next day's close" prediction with its concrete
+    target session. Before the bell this resolves to today; in every other
+    state it is the session after the last completed one. Cached per date.
+    """
+    # Look ahead up to 10 calendar days — more than enough to clear a long
+    # holiday weekend — and take the first scheduled session after `date`.
+    start = date + timedelta(days=1)
+    schedule = _NYSE_CALENDAR.schedule(
+        start_date=start, end_date=start + timedelta(days=10)
+    )
+    return schedule.index[0].date()
+
 def get_nyse_datetime():
     """Current datetime in NYSE timezone.
 


### PR DESCRIPTION
## §1 — Single status-driven header + dated section headers

Collapses the centered date `<h2>` + the separate `st.subheader("Today's Close Predictions")` into **one left-aligned status-driven header**, and replaces the generic "Next Day's Close Predictions" label with the **concrete target session date**.

### Full state matrix (both headers)
| State | Main header | Next-day section |
|---|---|---|
| Before open (trading day) | 🔴 Market Closed - **Displaying** Predictions for `<last session>` | Predictions for `<next session = today>` |
| Market open | 🔔 Live — Last Traded | Predictions for `<next session>` |
| After close (trading day) | 🔴 Today's Close Predictions and Actuals | Predictions for `<next session>` |
| Weekend/holiday | 🔴 Market Closed Weekend/Holiday - **Displaying** Predictions for `<last session>` | Predictions for `<next session>` |

- **"Displaying"** appears only on Before-Open + Weekend/Holiday — a deliberate "this is **not** today, it's a past-session accuracy recap" cue. Today/forward states omit it.
- **`next_session` = `next_trading_day(last_session)`** (XNYS calendar, skips weekends + holidays). Before the bell it resolves to today; otherwise the following session.
- `AFTER_MARKET_CLOSE` is split on `is_trading_day(today)` since `market_status()` collapses weekend/holiday and trading-day-after-close into one status.

### Why before-open shows the previous session (verified in the data flow)
The "today"-target models use **today's intraday** features (`Open/High/Low/Volume`, [feature_engineering.py:179](feature_engineering.py#L179)) fed from the last fetched row ([pipeline.py:57-58,128](pipeline.py#L57-L58)). Before the bell there is no today bar, so the main "today" prediction is really a re-prediction of the **last** session → shown as an accuracy recap. The real forward prediction (which targets today) is the next-day section, whose features include `Close` ([feature_engineering.py:181](feature_engineering.py#L181)).

### ⚠️ Follow-up (out of §1 scope)
Header **labels** are now correct. Making the main section's underlying numbers before-open actually be the last session's prediction+actual (the pipeline already computes a last-row prediction; the wiring/labeling of prediction-vs-actual is a separate change in `render_ui.py`) is tracked separately.

### Tests
`tests/test_header.py` — header copy per state, forward-header has no "Displaying" cue, `next_trading_day` over weekend + Memorial Day + Jul-4-observed edges. Full suite **30 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)