### PR TITLE
feat(ui): two-line centered status header polish (§1)

### DIFF
--- a/display_market_status.py
+++ b/display_market_status.py
@@ -23,26 +23,31 @@ def generate_market_status_header(status, last_date_str, today_is_trading_day=Tr
     trading-day-after-close case from the weekend/holiday case, which
     market_status() collapses into one status.
     """
+    subtitle = ""
     if status == "MARKET_OPEN":
         icon, title = "🔔", "Live — Last Traded"
     elif status == "BEFORE_MARKET_OPEN":
-        icon = "🔴"
-        title = f"Market Closed - Displaying Predictions for {last_date_str}"
+        icon, title = "🔴", "Market Closed"
+        subtitle = f"Displaying Predictions for {last_date_str}"
     elif status == "AFTER_MARKET_CLOSE":
         icon = "🔴"
         if today_is_trading_day:
             title = "Today's Close Predictions and Actuals"
         else:
-            title = (
-                "Market Closed Weekend/Holiday - Displaying Predictions for "
-                f"{last_date_str}"
-            )
+            title = "Market Closed Weekend/Holiday"
+            subtitle = f"Displaying Predictions for {last_date_str}"
     else:
         raise ValueError(f"Unknown market status: {status}")
 
+    # subtitle ~65% of title size (1.05rem vs 1.6rem), dark grey
+    subtitle_html = (
+        f"<div style='font-size: 1.05rem; color: #555555; margin-top: -4px;'>{subtitle}</div>"
+        if subtitle else ""
+    )
     return (
-        "<div style='text-align: left; margin-bottom: 8px;'>"
-        f"<h3 style='margin: 0;'>{icon} {title}</h3>"
+        "<div style='text-align: center; margin-bottom: 8px;'>"
+        f"<h3 style='margin: 0; font-size: 1.6rem;'>{icon} {title}</h3>"
+        f"{subtitle_html}"
         "</div>"
     )
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -25,7 +25,11 @@ DATE = "Friday, June 12"
 def test_before_open_shows_last_traded_date():
     html = generate_market_status_header("BEFORE_MARKET_OPEN", DATE)
     assert "🔴" in html
-    assert f"Market Closed - Displaying Predictions for {DATE}" in html
+    # status title on its own line; date in a separate dark-grey subtitle (no dash)
+    assert "Market Closed" in html
+    assert f"Displaying Predictions for {DATE}" in html
+    assert "color: #555555" in html
+    assert " - Displaying" not in html
 
 
 def test_market_open_live_no_date():
@@ -50,13 +54,15 @@ def test_after_close_weekend_holiday_shows_last_traded_date():
         "AFTER_MARKET_CLOSE", DATE, today_is_trading_day=False
     )
     assert "🔴" in html
-    assert f"Market Closed Weekend/Holiday - Displaying Predictions for {DATE}" in html
+    assert "Market Closed Weekend/Holiday" in html
+    assert f"Displaying Predictions for {DATE}" in html
+    assert " - Displaying" not in html
 
 
-def test_header_is_left_aligned_single_block():
+def test_header_is_centered_single_block():
     html = generate_market_status_header("AFTER_MARKET_CLOSE", DATE)
-    assert "text-align: left" in html
-    assert "text-align: center" not in html
+    assert "text-align: center" in html
+    assert "text-align: left" not in html
     # one header element, not a stacked date <h2> + <h3>
     assert html.count("<h3") == 1
     assert "<h2" not in html


### PR DESCRIPTION
Post-merge visual polish on the §1 status header (manually verified before-open + weekend states via MARKET_NOW).

- Two-line: status phrase (e.g. "Market Closed Weekend/Holiday") on its own line; "Displaying Predictions for `<date>`" as a separate dark-grey (#555) subtitle below — no inline dash.
- Centered (was left-aligned).
- Title 1.6rem, subtitle 1.05rem (~65%), subtitle `margin-top: -4px` to tighten the gap.

Applies to closed-states showing a past session (before open, weekend/holiday). Tests updated for the split + center. Full suite **30 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)