### PR TITLE
feat(§3): grouped stats panel with status-aware header

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -71,6 +71,39 @@ Branch `feat/stats-panel` off fresh `main`. Plan §3 in UI_UX_PLAN.md. Summary:
   `data.index[-1].date()` (reuse the same date the §1 subtitle shows).
 - Add `tests/test_stats_panel.py` (smoke-test rendered HTML strings per status).
 
+## Concurrency map — remaining work
+
+```
+main (§0✅ §1✅)
+│
+├── §3  feat/stats-panel       render_helpers.py:190-236  ─┐
+├── §2  feat/prediction-cards  render_helpers.py:61-90    ─┼─→ §4+§5 → §7
+├── §6  feat/chart-chrome      render_helpers.py:121,124  ─┘
+└── data-wiring (render_ui.py only)  ──────────────────────────── standalone
+```
+
+### Can run in parallel (all branch off same main, non-overlapping lines)
+- **§3, §2, §6** — all touch `render_helpers.py` but at line ranges that don't
+  overlap; branches off the same `main` commit merge without conflicts.
+- **Data-wiring follow-up** — touches `render_ui.py` only; zero overlap with
+  any `render_helpers.py` branch → always concurrent-safe with §2/§3/§6.
+
+### Must be sequential
+- **§4+§5 after §2** — §5 bolds the delta in `preds_sameline()` (line 75),
+  but §2 *replaces* `preds_sameline()` with two model cards. Run §5 on the new
+  cards §2 creates, not the old strip. Merge §2 first, then branch §4+§5 off
+  updated main.
+- **§7 last** — final visual pass across `render_helpers.py` (prediction cards,
+  stats panel, chart tokens). Must follow §2, §3, §4+§5, and §6 so the theme
+  token dict is applied to completed, final markup — not draft markup that §2/§3
+  will reshape.
+
+### Recommended execution order
+1. **Now (parallel):** §3 + §2 + §6 + data-wiring — branch all off current main,
+   merge in any order (no conflicts).
+2. **After §2 merges:** §4+§5 off updated main.
+3. **After §2 + §3 + §4+§5 + §6 all merged:** §7.
+
 ## ⚠️ Open follow-up (own branch, before/after §3 — user's call)
 **Before-open prediction-vs-actual data wiring.** §1 fixed header *labels* only.
 Before open the main section's numbers are the today-model run on the last row

--- a/UI_UX_PLAN.md
+++ b/UI_UX_PLAN.md
@@ -14,7 +14,7 @@ first because every header and stats decision branches off it.
 | — | gitignore `*_data.csv` | direct to main | ✅ merged (76a34cd) |
 | §1 | Single status-driven header | `feat/single-header` | ✅ merged (PR #10) |
 | — | §1 header style polish (2-line centered, grey subtitle, tight gap) | `feat/header-style`, `fix/header-gap` | ✅ merged (PR #11, #12) |
-| §3 | Grouped, status-aware stats panel | `feat/stats-panel` | ⏭ next |
+| §3 | Grouped, status-aware stats panel | `feat/stats-panel` | 🔄 in progress |
 | §2 | Two prediction model cards | `feat/prediction-cards` | todo |
 | §4+§5 | Close-card number color + bold deltas | `feat/close-color-deltas` | todo |
 | §6 | Strip chart chrome | `feat/chart-chrome` | todo |

--- a/render_helpers.py
+++ b/render_helpers.py
@@ -187,9 +187,11 @@ def display_tradingview_chart_from_data(ticker, latest_data):
     components.html(widget_html, height=500, scrolling=False)
 
 
-def create_grid_display(open_val, high_val, low_val, prev_close_val, close_val, volume):
+def create_grid_display(open_val, high_val, low_val, prev_close_val, close_val, volume, session_date=None):
     def format_price(value):
         return f"${value:,.2f}"
+
+    status = market_status()
 
     close_is_up = close_val >= prev_close_val
     close_bg = "rgba(34,197,94,0.12)" if close_is_up else "rgba(239,68,68,0.12)"
@@ -201,7 +203,7 @@ def create_grid_display(open_val, high_val, low_val, prev_close_val, close_val, 
         "High",
         "Low",
         "Prev Close",
-        "Last Traded" if market_status() == "MARKET_OPEN" else "Close",
+        "Last Traded" if status == "MARKET_OPEN" else "Close",
         "Volume",
     ]
     values = [
@@ -227,13 +229,25 @@ def create_grid_display(open_val, high_val, low_val, prev_close_val, close_val, 
             f'</div>'
         )
 
-    html = (
-        '<div style="margin: 8px 0 2px 0; display: grid; '
+    if status == "MARKET_OPEN":
+        panel_header = "Today's Data"
+    else:
+        panel_header = session_date.strftime('%A, %B %d') if session_date else "Last Session"
+
+    grid = (
+        '<div style="display: grid; '
         'grid-template-columns: repeat(auto-fit, minmax(145px, 1fr)); gap: 12px;">'
         + ''.join(grid_items)
         + '</div>'
     )
-    return html
+    return (
+        '<div style="border: 1px solid rgba(148,163,184,0.25); border-radius: 18px; '
+        'padding: 16px 16px 14px; margin: 8px 0 2px 0;">'
+        f'<div style="font-size: 0.78em; font-weight: 700; letter-spacing: 0.06em; '
+        f'text-transform: uppercase; color: #475569; margin-bottom: 10px;">{panel_header}</div>'
+        + grid
+        + '</div>'
+    )
 
 
 def search_and_add_ticker(new_ticker):

--- a/render_ui.py
+++ b/render_ui.py
@@ -95,6 +95,7 @@ def display_results(predictions):
                 formatted_data["Prev Close"],
                 formatted_data["Close"],
                 formatted_data["Volume"],
+                session_date=last_available_date,
             )
             st.markdown(grid_html, unsafe_allow_html=True)
 

--- a/tests/test_stats_panel.py
+++ b/tests/test_stats_panel.py
@@ -1,0 +1,85 @@
+"""Isolated tests for the grouped stats panel (plan section 3).
+
+Smoke-tests the HTML output of create_grid_display() per market status.
+Locks: bordered panel wrapper present, status-aware header text correct,
+all six metric cards present.
+
+State → panel header:
+  MARKET_OPEN        → "Today's Data"
+  BEFORE_MARKET_OPEN → session date string  (e.g. "Friday, June 12")
+  AFTER_MARKET_CLOSE → session date string
+  session_date=None  → "Last Session" fallback
+"""
+from datetime import date
+
+import pytest
+
+from render_helpers import create_grid_display
+
+
+SAMPLE = dict(
+    open_val=100.0,
+    high_val=105.0,
+    low_val=98.0,
+    prev_close_val=99.0,
+    close_val=103.0,
+    volume=1_000_000,
+)
+SESSION_DATE = date(2026, 6, 12)  # a Friday
+
+
+def _html(monkeypatch, status, session_date=SESSION_DATE):
+    monkeypatch.setattr("render_helpers.market_status", lambda: status)
+    return create_grid_display(**SAMPLE, session_date=session_date)
+
+
+# --- panel wrapper -----------------------------------------------------------
+
+def test_panel_border_present(monkeypatch):
+    html = _html(monkeypatch, "MARKET_OPEN")
+    assert "border-radius: 18px" in html
+
+
+# --- header text -------------------------------------------------------------
+
+def test_header_market_open(monkeypatch):
+    html = _html(monkeypatch, "MARKET_OPEN")
+    assert "Today's Data" in html
+
+
+def test_header_before_open(monkeypatch):
+    html = _html(monkeypatch, "BEFORE_MARKET_OPEN")
+    assert "Friday, June 12" in html
+    assert "Today's Data" not in html
+
+
+def test_header_after_close(monkeypatch):
+    html = _html(monkeypatch, "AFTER_MARKET_CLOSE")
+    assert "Friday, June 12" in html
+    assert "Today's Data" not in html
+
+
+def test_header_no_session_date_fallback(monkeypatch):
+    monkeypatch.setattr("render_helpers.market_status", lambda: "BEFORE_MARKET_OPEN")
+    html = create_grid_display(**SAMPLE, session_date=None)
+    assert "Last Session" in html
+
+
+# --- metric cards present ----------------------------------------------------
+
+@pytest.mark.parametrize("status", ["MARKET_OPEN", "BEFORE_MARKET_OPEN", "AFTER_MARKET_CLOSE"])
+def test_all_metrics_present(monkeypatch, status):
+    html = _html(monkeypatch, status)
+    for label in ("OPEN", "HIGH", "LOW", "PREV CLOSE", "VOLUME"):
+        assert label in html.upper()
+
+
+def test_close_label_open(monkeypatch):
+    html = _html(monkeypatch, "MARKET_OPEN")
+    assert "LAST TRADED" in html.upper()
+
+
+def test_close_label_closed(monkeypatch):
+    html = _html(monkeypatch, "BEFORE_MARKET_OPEN")
+    assert "CLOSE" in html.upper()
+    assert "LAST TRADED" not in html.upper()


### PR DESCRIPTION
## Summary
- Wraps the floating OHLC/Volume cards in a single bordered panel with a header
- Header: "Today's Data" when market open; last session date (e.g. "Friday, June 12") when closed — same source as §1 subtitle
- `create_grid_display()` gains `session_date` param; `render_ui.py` passes `last_available_date`
- Adds `tests/test_stats_panel.py` (10 cases)

## Test plan
- [ ] `pytest -q` — 40 passing
- [ ] Manual: hit Predict → panel border + "TODAY'S DATA" header visible (market open)
- [ ] Manual: `$env:MARKET_NOW="2026-06-13T08:00"` → panel shows session date header

🤖 Generated with [Claude Code](https://claude.com/claude-code)