### PR TITLE
feat(§6): strip chart chrome noise

### DIFF
--- a/UI_UX_PLAN.md
+++ b/UI_UX_PLAN.md
@@ -15,9 +15,9 @@ first because every header and stats decision branches off it.
 | §1 | Single status-driven header | `feat/single-header` | ✅ merged (PR #10) |
 | — | §1 header style polish (2-line centered, grey subtitle, tight gap) | `feat/header-style`, `fix/header-gap` | ✅ merged (PR #11, #12) |
 | §3 | Grouped, status-aware stats panel | `feat/stats-panel` | ✅ merged (PR #13) |
-| §2 | Two prediction model cards | `feat/prediction-cards` | ⏭ next |
+| §2 | Two prediction model cards | `feat/prediction-cards` | 🔄 in progress |
 | §4+§5 | Close-card number color + bold deltas | `feat/close-color-deltas` | todo |
-| §6 | Strip chart chrome | `feat/chart-chrome` | todo |
+| §6 | Strip chart chrome | `feat/chart-chrome` | 🔄 in progress |
 | §7 | Dark theme + light toggle | `feat/dark-theme-toggle` | todo |
 
 **Workflow per section:** branch off fresh `main` → implement → add/extend

--- a/render_helpers.py
+++ b/render_helpers.py
@@ -114,14 +114,15 @@ def display_tradingview_chart_from_data(ticker, latest_data):
         )
 
     chart_json = str(rows).replace("'", '"')
-    widget_html = f"""
+    components.html(generate_chart_widget_html(ticker, chart_json), height=500, scrolling=False)
+
+
+def generate_chart_widget_html(ticker, chart_json):
+    """Build TradingView chart HTML. Pure function for testability."""
+    return f"""
     <div style="margin: 8px 0 18px 0; border: 1px solid rgba(51,65,85,0.8); border-radius: 18px; overflow: hidden; box-shadow: 0 16px 36px rgba(2,6,23,0.35); background: linear-gradient(180deg, #0f172a 0%, #111827 100%);">
       <div style="padding: 14px 16px; border-bottom: 1px solid rgba(148,163,184,0.14); display: flex; justify-content: space-between; align-items: center; gap: 12px; background: linear-gradient(90deg, rgba(15,23,42,0.96), rgba(30,41,59,0.92));">
-        <div>
-          <div style="font-size: 0.72em; letter-spacing: 0.16em; text-transform: uppercase; color: #94a3b8; margin-bottom: 4px;">TradingView Style Chart</div>
-          <div style="font-weight: 800; font-size: 1.1em; color: #f8fafc;">{ticker.upper()} · Last 10 Trading Days</div>
-        </div>
-        <div style="font-size: 0.85em; color: #cbd5e1;">OHLC candles from local market data</div>
+        <div style="font-weight: 800; font-size: 1.1em; color: #f8fafc;">{ticker.upper()} · Last 10 Trading Days</div>
       </div>
       <div id="tv_chart_{ticker}" style="height: 420px; width: 100%;"></div>
     </div>
@@ -184,7 +185,6 @@ def display_tradingview_chart_from_data(ticker, latest_data):
       }})();
     </script>
     """
-    components.html(widget_html, height=500, scrolling=False)
 
 
 def create_grid_display(open_val, high_val, low_val, prev_close_val, close_val, volume, session_date=None):

--- a/tests/test_chart_chrome.py
+++ b/tests/test_chart_chrome.py
@@ -1,0 +1,38 @@
+"""Isolated tests for §6 chart chrome strip.
+
+Locks: eyebrow label and OHLC caption removed; ticker title kept.
+Tested via generate_chart_widget_html() — pure function, no Streamlit dependency.
+"""
+from render_helpers import generate_chart_widget_html
+
+DUMMY_JSON = "[]"
+
+
+def test_eyebrow_label_removed():
+    html = generate_chart_widget_html("AAPL", DUMMY_JSON)
+    assert "TradingView Style Chart" not in html
+
+
+def test_ohlc_caption_removed():
+    html = generate_chart_widget_html("AAPL", DUMMY_JSON)
+    assert "OHLC candles from local market data" not in html
+
+
+def test_ticker_title_kept():
+    html = generate_chart_widget_html("AAPL", DUMMY_JSON)
+    assert "AAPL · Last 10 Trading Days" in html
+
+
+def test_ticker_uppercased():
+    html = generate_chart_widget_html("msft", DUMMY_JSON)
+    assert "MSFT · Last 10 Trading Days" in html
+
+
+def test_chart_json_embedded():
+    html = generate_chart_widget_html("AAPL", '[{"time": 1, "open": 1}]')
+    assert '[{"time": 1, "open": 1}]' in html
+
+
+def test_chart_container_id_uses_ticker():
+    html = generate_chart_widget_html("TSLA", DUMMY_JSON)
+    assert 'id="tv_chart_TSLA"' in html


### PR DESCRIPTION
## Summary
- Remove "TradingView Style Chart" eyebrow label
- Remove "OHLC candles from local market data" caption
- Only `TICKER · Last 10 Trading Days` remains as chart title
- Extract HTML to `generate_chart_widget_html()` (pure fn, enables direct testing)

## Test plan
- [x] `pytest tests/test_chart_chrome.py` — 6 cases green
- [x] `pytest tests/ -q` — 46 passed
- [x] Manual visual check passed (user confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)