### PR TITLE
feat(§delta): inline Δ label on prediction cards

### DIFF
--- a/render_helpers.py
+++ b/render_helpers.py
@@ -58,7 +58,7 @@ def extract_and_format_ticker_data(latest_data):
     return formatted_data
 
 
-def _model_card_html(model_name, predicted_price, delta, delta_color, delta_sign):
+def _model_card_html(model_name, predicted_price, delta, delta_color, delta_sign, delta_label):
     return (
         '<div style="flex: 1; min-width: 160px; padding: 16px; border-radius: 14px; '
         'border: 1px solid rgba(148,163,184,0.18); '
@@ -68,8 +68,10 @@ def _model_card_html(model_name, predicted_price, delta, delta_color, delta_sign
         f'text-transform: uppercase; color: #475569; margin-bottom: 8px;">{model_name}</div>'
         f'<div style="font-size: 1.5em; font-weight: 800; color: #0f172a; line-height: 1.2; '
         f'margin-bottom: 4px;">${predicted_price:.2f}</div>'
-        f'<div style="font-size: 1.05em; font-weight: 700; color: {delta_color};">'
-        f'({delta_sign}${abs(delta):.2f})</div>'
+        f'<div style="display: flex; align-items: center; justify-content: center; gap: 5px;">'
+        f'<span style="font-size: 0.7em; font-weight: 600; color: #94a3b8; white-space: nowrap;">{delta_label}</span>'
+        f'<span style="font-size: 1.05em; font-weight: 700; color: {delta_color};">({delta_sign}${abs(delta):.2f})</span>'
+        f'</div>'
         '</div>'
     )
 
@@ -82,7 +84,7 @@ def _prediction_cards_container_html(cards_html):
     )
 
 
-def generate_prediction_cards_html(predictions, current_val):
+def generate_prediction_cards_html(predictions, current_val, delta_label):
     """Build HTML for two side-by-side model prediction cards."""
     cards_html = ""
     for i, prediction in enumerate(predictions):
@@ -90,14 +92,14 @@ def generate_prediction_cards_html(predictions, current_val):
         delta = prediction - current_val
         delta_color = "#4CAF50" if delta >= 0 else "#FF5252"
         delta_sign = "+" if delta > 0 else ("-" if delta < 0 else "")
-        cards_html += _model_card_html(model_name, prediction, delta, delta_color, delta_sign)
+        cards_html += _model_card_html(model_name, prediction, delta, delta_color, delta_sign, delta_label)
     return _prediction_cards_container_html(cards_html)
 
 
-def display_predictions(predictions, current_val):
+def display_predictions(predictions, current_val, delta_label):
     """Display predictions as two side-by-side model cards."""
     st.markdown(
-        generate_prediction_cards_html(predictions, current_val),
+        generate_prediction_cards_html(predictions, current_val, delta_label),
         unsafe_allow_html=True,
     )
 

--- a/render_ui.py
+++ b/render_ui.py
@@ -23,16 +23,8 @@ def enforce_max_tickers():
         ]
 
 
-def _session_ref_caption(session_date, actual_close):
-    """Caption text for closed-market prediction display.
-
-    Clarifies that the prediction delta is vs the last session's actual close,
-    not a forward-looking gap from a live price.
-    """
-    return (
-        f"Δ vs {session_date.strftime('%A, %b %d')} "
-        f"actual close · ${actual_close:.2f}"
-    )
+def _delta_caption(is_open):
+    return "Δ from last traded" if is_open else "Δ from close"
 
 
 def display_results(predictions):
@@ -113,12 +105,7 @@ def display_results(predictions):
             actual_close = formatted_data["Close"]
 
             # Display two model cards with predictions
-            display_predictions(grouped_predictions[ticker], actual_close)
-
-            # When market is closed, surface the reference so users see
-            # this as an accuracy recap, not a forward prediction.
-            if status != "MARKET_OPEN" and last_available_date is not None:
-                st.caption(_session_ref_caption(last_available_date, actual_close))
+            display_predictions(grouped_predictions[ticker], actual_close, _delta_caption(status == "MARKET_OPEN"))
 
             # Chart sits directly below the prediction strip and accuracy note
             display_tradingview_chart_from_data(ticker, latest_data)
@@ -180,7 +167,7 @@ def display_results(predictions):
                         )
 
                         # Display two model cards for next-day predictions
-                        display_predictions(predictions, current_close)
+                        display_predictions(predictions, current_close, _delta_caption(status == "MARKET_OPEN"))
 
                         st.markdown('</div>', unsafe_allow_html=True)
 


### PR DESCRIPTION
## Summary
- Replace standalone `st.caption` with inline label rendered left of price diff inside each model card
- Closed market: `Δ from close` — open market: `Δ from last traded`
- Removes redundant price value that duplicated the grid below the chart

## Test plan
- [x] Verified `Δ from close` renders correctly in closed-market state
- [x] Verified `Δ from last traded` renders correctly with market-open override
- [x] Confirmed label is inline left of `(+$X.XX)` in both model cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)