### PR TITLE
§7/dm5: responsive even-distribution stats grid

### DIFF
--- a/DARK_MODE_PLAN.md
+++ b/DARK_MODE_PLAN.md
@@ -1,6 +1,6 @@
 # Dark Mode — Polish Pass Plan
 
-Status: DM3 done ✅ · Owner: clpatel · Started: 2026-06-14
+Status: DM3 done ✅ · DM6 claimed · DM5 in progress · Owner: clpatel · Started: 2026-06-14
 Branch: `feat/dark-theme-toggle` (all six items land here — see Branching below)
 
 This plan is the §7 follow-through from [UI_UX_PLAN.md](UI_UX_PLAN.md). §7 introduced

--- a/render_helpers.py
+++ b/render_helpers.py
@@ -325,12 +325,12 @@ def create_grid_display(open_val, high_val, low_val, prev_close_val, close_val, 
 
     return (
         '<style>'
-        '.sg6{display:grid;gap:12px;margin:8px 0 2px 0;grid-template-columns:repeat(2,1fr)}'
-        '@container (min-width:520px){.sg6{grid-template-columns:repeat(3,1fr)}}'
-        '@container (min-width:960px){.sg6{grid-template-columns:repeat(6,1fr)}}'
+        '.stats-grid-6{display:grid;gap:12px;margin:8px 0 2px 0;grid-template-columns:repeat(2,1fr)}'
+        '@container stats-grid (min-width:520px){.stats-grid-6{grid-template-columns:repeat(3,1fr)}}'
+        '@container stats-grid (min-width:960px){.stats-grid-6{grid-template-columns:repeat(6,1fr)}}'
         '</style>'
-        '<div style="container-type:inline-size">'
-        '<div class="sg6">'
+        '<div style="container-type:inline-size;container-name:stats-grid">'
+        '<div class="stats-grid-6">'
         + ''.join(grid_items)
         + '</div></div>'
     )

--- a/render_helpers.py
+++ b/render_helpers.py
@@ -324,11 +324,15 @@ def create_grid_display(open_val, high_val, low_val, prev_close_val, close_val, 
         )
 
     return (
-        '<div style="display: grid; '
-        'grid-template-columns: repeat(auto-fit, minmax(145px, 1fr)); gap: 12px; '
-        'margin: 8px 0 2px 0;">'
+        '<style>'
+        '.sg6{display:grid;gap:12px;margin:8px 0 2px 0;grid-template-columns:repeat(2,1fr)}'
+        '@container (min-width:520px){.sg6{grid-template-columns:repeat(3,1fr)}}'
+        '@container (min-width:960px){.sg6{grid-template-columns:repeat(6,1fr)}}'
+        '</style>'
+        '<div style="container-type:inline-size">'
+        '<div class="sg6">'
         + ''.join(grid_items)
-        + '</div>'
+        + '</div></div>'
     )
 
 

--- a/tests/test_dark_theme.py
+++ b/tests/test_dark_theme.py
@@ -96,10 +96,14 @@ def test_dark_close_down_color(monkeypatch):
 def test_grid_responsive_breakpoints(monkeypatch):
     monkeypatch.setattr("render_helpers.market_status", lambda: "AFTER_MARKET_CLOSE")
     html = create_grid_display(100.0, 105.0, 98.0, 99.0, 103.0, 1_000_000, theme_name="dark")
-    assert "@container (min-width:520px)" in html
-    assert "@container (min-width:960px)" in html
+    assert "@container stats-grid (min-width:520px)" in html
+    assert "@container stats-grid (min-width:960px)" in html
+    assert "container-name:stats-grid" in html
+    assert "container-type:inline-size" in html
+    assert "repeat(2,1fr)" in html
     assert "repeat(3,1fr)" in html
     assert "repeat(6,1fr)" in html
+    assert "auto-fit" not in html
 
 
 # ── _close_color theme-aware ──────────────────────────────────────────────────

--- a/tests/test_dark_theme.py
+++ b/tests/test_dark_theme.py
@@ -91,6 +91,17 @@ def test_dark_close_down_color(monkeypatch):
     assert THEME["dark"]["close_down"] in html
 
 
+# ── DM5: responsive even-distribution grid ────────────────────────────────────
+
+def test_grid_responsive_breakpoints(monkeypatch):
+    monkeypatch.setattr("render_helpers.market_status", lambda: "AFTER_MARKET_CLOSE")
+    html = create_grid_display(100.0, 105.0, 98.0, 99.0, 103.0, 1_000_000, theme_name="dark")
+    assert "@container (min-width:520px)" in html
+    assert "@container (min-width:960px)" in html
+    assert "repeat(3,1fr)" in html
+    assert "repeat(6,1fr)" in html
+
+
 # ── _close_color theme-aware ──────────────────────────────────────────────────
 
 def test_close_color_up_dark():


### PR DESCRIPTION
## Summary
- Replace `repeat(auto-fit, minmax(145px, 1fr))` with container-query breakpoints for even tile distribution:
  - **\u2265960px container:** 6 columns → 1 row of 6 tiles
  - **520–959px:** 3 columns → 2 rows of 3 tiles  
  - **<520px:** 2 columns → 3 rows of 2 tiles
- Grid always centered via `1fr` columns (auto-fill container width)
- Added `test_grid_responsive_breakpoints` asserting `@container` rules present

## Manual test
Verified at http://localhost:8503 — tiles distribute evenly at all widths.

## Branch
`feat/dm5-stats-grid` — worktree `StockPredictors-dm5-stats-grid`