### PR TITLE
fix: stabilize Render ticker search and yfinance tracing

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -5,6 +5,7 @@ import os
 import threading
 from pathlib import Path
 import shutil
+from trace_utils import trace_event
 
 try:
     from yfinance import cache as yf_cache
@@ -44,13 +45,12 @@ def debug_yfinance_cache_location():
     Print the resolved cache path and current filesystem state for Render logs.
     """
     cache_dir = configure_yfinance_cache()
-    print(f"yfinance cache path: {cache_dir}")
-    print(f"yfinance cache exists: {cache_dir.exists()}")
+    trace_event("yfinance.cache_location", path=str(cache_dir), exists=cache_dir.exists())
     if cache_dir.exists():
         try:
-            print(f"yfinance cache entries: {[p.name for p in cache_dir.iterdir()]}")
+            trace_event("yfinance.cache_entries", entries=[p.name for p in cache_dir.iterdir()])
         except Exception as exc:
-            print(f"yfinance cache listing failed: {exc}")
+            trace_event("yfinance.cache_listing_failed", error=str(exc))
     return cache_dir
 
 
@@ -63,7 +63,7 @@ def clear_yfinance_cache():
         if cache_dir.exists():
             shutil.rmtree(cache_dir, ignore_errors=True)
         cache_dir.mkdir(parents=True, exist_ok=True)
-        print(f"Cleared yfinance cache: {cache_dir}")
+        trace_event("yfinance.cache_cleared", path=str(cache_dir))
 
 
 def _download_with_retry(ticker, start_date, end_date):
@@ -72,17 +72,42 @@ def _download_with_retry(ticker, start_date, end_date):
     """
     configure_yfinance_cache()
     try:
+        trace_event(
+            "yfinance.download.start",
+            ticker=ticker,
+            start_date=str(start_date),
+            end_date=str(end_date),
+        )
         df = yf.download(ticker, start=start_date, end=end_date)
+        trace_event(
+            "yfinance.download.finish",
+            ticker=ticker,
+            empty=getattr(df, "empty", None),
+            rows=len(df) if df is not None else None,
+        )
         if _should_refresh_after_download(ticker, df):
-            print(f"yfinance returned a retryable failure for {ticker}; clearing cache and retrying once")
+            trace_event("yfinance.download.retryable_failure", ticker=ticker)
             clear_yfinance_cache()
+            trace_event("yfinance.download.retry_start", ticker=ticker)
             df = yf.download(ticker, start=start_date, end=end_date)
+            trace_event(
+                "yfinance.download.retry_finish",
+                ticker=ticker,
+                empty=getattr(df, "empty", None),
+                rows=len(df) if df is not None else None,
+            )
         return df
     except Exception as exc:
         message = str(exc).lower()
+        trace_event(
+            "yfinance.download.exception",
+            ticker=ticker,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
         if os.environ.get("YFINANCE_TEST_CACHE_REFRESH", "").lower() in ("1", "true", "yes"):
             if _YF_TEST_CACHE_REFRESH_MESSAGE in message:
-                print(f"yfinance test cache refresh trigger for {ticker}: {exc}")
+                trace_event("yfinance.test_cache_refresh", ticker=ticker, error=str(exc))
                 clear_yfinance_cache()
                 return yf.download(ticker, start=start_date, end=end_date)
 
@@ -96,7 +121,7 @@ def _download_with_retry(ticker, start_date, end_date):
             "malformed",
         )
         if any(signal in message for signal in cache_error_signals) or "operationalerror" in type(exc).__name__.lower():
-            print(f"yfinance cache error for {ticker}: {exc}")
+            trace_event("yfinance.cache_error", ticker=ticker, error=str(exc))
             clear_yfinance_cache()
             return yf.download(ticker, start=start_date, end=end_date)
         raise
@@ -118,7 +143,15 @@ def _should_refresh_after_download(ticker, df):
     if hasattr(yf_shared, "_ERRORS"):
         error_text = str(yf_shared._ERRORS.get(ticker_key, "")).lower()
 
-    return any(marker in error_text for marker in _YF_RETRY_ERROR_MARKERS)
+    should_refresh = any(marker in error_text for marker in _YF_RETRY_ERROR_MARKERS)
+    if error_text:
+        trace_event(
+            "yfinance.shared_error",
+            ticker=ticker_key,
+            should_refresh=should_refresh,
+            error=error_text,
+        )
+    return should_refresh
 
 
 def invalidate_yfinance_cache():
@@ -162,10 +195,17 @@ def fetch_data(ticker, end_date, start_date="2008-01-01", use_local_data=False):
     local_file = f"{ticker}_data.csv"
 
     if use_local_data and os.path.exists(local_file):
+        trace_event("fetch_data.local_file", ticker=ticker, path=local_file)
         df = custom_read_csv(local_file)
         print(f"Loaded data from local file: {local_file}")
     else:
         # Fetch data from yfinance
+        trace_event(
+            "fetch_data.remote_start",
+            ticker=ticker,
+            start_date=str(start_date),
+            end_date=str(end_date),
+        )
         df = _download_with_retry(ticker, start_date, end_date)
         
         # Create MultiIndex columns if not already present
@@ -181,8 +221,9 @@ def fetch_data(ticker, end_date, start_date="2008-01-01", use_local_data=False):
             df_to_save = df.copy()
             df_to_save.index.name = 'Date'
             df_to_save.to_csv(local_file)
-            print(f"Fetched data from yfinance and saved to: {local_file}")
+            trace_event("fetch_data.remote_saved", ticker=ticker, path=local_file, rows=len(df))
         else:
+            trace_event("fetch_data.remote_empty", ticker=ticker)
             raise ValueError(f"No data retrieved for ticker {ticker} from yfinance")
 
     return df

--- a/pipeline.py
+++ b/pipeline.py
@@ -11,6 +11,28 @@ from feature_engineering import add_technical_indicators, get_feature_columns
 from model import train_model
 import traceback
 
+
+def _feature_value(frame, feature, ticker, fill_value=0.0):
+    try:
+        value = frame[(feature, ticker)].iloc[0]
+    except Exception:
+        return fill_value
+
+    if isinstance(value, (np.ndarray, list, tuple)):
+        value = np.asarray(value).squeeze()
+        if np.asarray(value).ndim != 0:
+            return fill_value
+        value = value.item()
+
+    if pd.isna(value):
+        return fill_value
+
+    return float(value)
+
+
+def _prediction_scalar(prediction):
+    return float(np.asarray(prediction).squeeze().item())
+
 def execute_pipeline(tickers):
     """Process each ticker independently with models trained specifically for that ticker"""
     # Initialize storage for predictions and trained models
@@ -125,21 +147,27 @@ def execute_pipeline(tickers):
                 
                 # --- Todays Close Linear Regression Prediction using last_row_basic ---
                 feature_cols_linear_today = get_feature_columns(model_type="linear_regression", target="today")
-                prediction_input_linear_today = [last_row_basic[(col, ticker)].iloc[0] for col in feature_cols_linear_today]
+                prediction_input_linear_today = [
+                    _feature_value(last_row_basic, col, ticker, fill_value=0.0)
+                    for col in feature_cols_linear_today
+                ]
                 linear_prediction_data_today = np.array(prediction_input_linear_today).reshape(1, -1)
                 linear_prediction_scaled_today = X_scaler_linear_today.transform(linear_prediction_data_today)
                 linear_prediction_today = linear_model_today.predict(linear_prediction_scaled_today)
                 linear_prediction_today = y_scaler_linear_today.inverse_transform(linear_prediction_today.reshape(-1, 1))
-                todays_close_predictions.append((ticker, float(linear_prediction_today[0])))
+                todays_close_predictions.append((ticker, _prediction_scalar(linear_prediction_today)))
 
                 # Linear Regression prediction for next day
                 feature_cols_linear_next = get_feature_columns(model_type="linear_regression", target="next_day")
-                prediction_input_linear_next = [last_row_basic[(col, ticker)].iloc[0] for col in feature_cols_linear_next]
+                prediction_input_linear_next = [
+                    _feature_value(last_row_basic, col, ticker, fill_value=0.0)
+                    for col in feature_cols_linear_next
+                ]
                 linear_prediction_data_next = np.array(prediction_input_linear_next).reshape(1, -1)
                 linear_prediction_scaled_next = X_scaler_linear_next_day.transform(linear_prediction_data_next)
                 linear_prediction_next = linear_model_next_day.predict(linear_prediction_scaled_next)
                 linear_prediction_next = y_scaler_linear_next_day.inverse_transform(linear_prediction_next.reshape(-1, 1))
-                next_days_close_predictions.append((ticker, float(linear_prediction_next[0])))
+                next_days_close_predictions.append((ticker, _prediction_scalar(linear_prediction_next)))
 
                 # XGBoost prediction for today's close
                 feature_cols_xgb_today = get_feature_columns(model_type="xgboost", target="today")
@@ -159,7 +187,7 @@ def execute_pipeline(tickers):
                     X_scaler_xgb_today,
                     y_scaler_xgb_today
                 )
-                todays_close_predictions.append((ticker, float(xgb_prediction_today[0])))
+                todays_close_predictions.append((ticker, _prediction_scalar(xgb_prediction_today)))
 
                 # Next day's close prediction
                 feature_cols_xgb_next = get_feature_columns(model_type="xgboost", target="next_day")
@@ -178,12 +206,12 @@ def execute_pipeline(tickers):
                     X_scaler_xgb_next_day,
                     y_scaler_xgb_next_day
                 )
-                next_days_close_predictions.append((ticker, float(xgb_prediction_next_day[0])))
+                next_days_close_predictions.append((ticker, _prediction_scalar(xgb_prediction_next_day)))
                 
                 # Fix debugging output formatting
-                print(f"DEBUG XGBoost today's close for {ticker}: {float(xgb_prediction_today[0]):.2f}")
-                print(f"DEBUG Linear Regression next day close for {ticker}: {float(linear_prediction_next[0]):.2f}")
-                print(f"DEBUG XGBoost next day close for {ticker}: {float(xgb_prediction_next_day[0]):.2f}")
+                print(f"DEBUG XGBoost today's close for {ticker}: {_prediction_scalar(xgb_prediction_today):.2f}")
+                print(f"DEBUG Linear Regression next day close for {ticker}: {_prediction_scalar(linear_prediction_next):.2f}")
+                print(f"DEBUG XGBoost next day close for {ticker}: {_prediction_scalar(xgb_prediction_next_day):.2f}")
                 
             except Exception as e:
                 print(f"Error making predictions for {ticker}: {str(e)}")

--- a/pipeline.py
+++ b/pipeline.py
@@ -10,6 +10,7 @@ from data_processor import preprocess_data
 from feature_engineering import add_technical_indicators, get_feature_columns
 from model import train_model
 import traceback
+from trace_utils import trace_event
 
 
 def _feature_value(frame, feature, ticker, fill_value=0.0):
@@ -35,6 +36,7 @@ def _prediction_scalar(prediction):
 
 def execute_pipeline(tickers):
     """Process each ticker independently with models trained specifically for that ticker"""
+    trace_event("pipeline.enter", tickers=tickers)
     # Initialize storage for predictions and trained models
     todays_close_predictions = []
     next_days_close_predictions = []
@@ -45,16 +47,23 @@ def execute_pipeline(tickers):
     
     for ticker in tickers:
         st.markdown(f"Processing {ticker}...")
-        print(f"\nProcessing {ticker}...\n")
+        trace_event("pipeline.ticker_start", ticker=ticker)
         
         try:
             # Get training data using NYSE timezone
             nyse_date = get_nyse_date()
+            trace_event("pipeline.before_fetch_data", ticker=ticker, nyse_date=str(nyse_date))
             stock_data = fetch_data(ticker, nyse_date + timedelta(days=2))
-            print(f"\n\nFetched stock data for {nyse_date + timedelta(days=1)} {ticker}:\n{stock_data.tail()}\n\n")  # Debugging line
+            trace_event(
+                "pipeline.after_fetch_data",
+                ticker=ticker,
+                empty=stock_data.empty,
+                rows=len(stock_data),
+                columns=list(stock_data.columns)[:8],
+            )
             
             if stock_data.empty:
-                print(f"\n\nNo data returned for {ticker}\n\n")
+                trace_event("pipeline.ticker_empty_data", ticker=ticker)
                 continue
             
             # Process base data (only cleans Prev Close NaNs)
@@ -82,6 +91,12 @@ def execute_pipeline(tickers):
             # Create training datasets by dropping NaNs only once
             train_ready_data_linear = processed_data.dropna().copy()
             train_ready_data_xgb = train_ready_data_xgb.dropna().copy()
+            trace_event(
+                "pipeline.training_data_ready",
+                ticker=ticker,
+                linear_rows=len(train_ready_data_linear),
+                xgb_rows=len(train_ready_data_xgb),
+            )
             
             # Train separate models for this specific ticker
             models[ticker] = {
@@ -132,6 +147,7 @@ def execute_pipeline(tickers):
             )
             
             try:
+                trace_event("pipeline.prediction_start", ticker=ticker)
                 # Make predictions using this ticker's specific models
                 linear_model_today = models[ticker]['linear_today']['model']
                 X_scaler_linear_today, y_scaler_linear_today = models[ticker]['linear_today']['scalers']
@@ -209,15 +225,31 @@ def execute_pipeline(tickers):
                 next_days_close_predictions.append((ticker, _prediction_scalar(xgb_prediction_next_day)))
                 
                 # Fix debugging output formatting
-                print(f"DEBUG XGBoost today's close for {ticker}: {_prediction_scalar(xgb_prediction_today):.2f}")
-                print(f"DEBUG Linear Regression next day close for {ticker}: {_prediction_scalar(linear_prediction_next):.2f}")
-                print(f"DEBUG XGBoost next day close for {ticker}: {_prediction_scalar(xgb_prediction_next_day):.2f}")
+                trace_event(
+                    "pipeline.prediction_finish",
+                    ticker=ticker,
+                    linear_today=_prediction_scalar(linear_prediction_today),
+                    linear_next=_prediction_scalar(linear_prediction_next),
+                    xgb_today=_prediction_scalar(xgb_prediction_today),
+                    xgb_next=_prediction_scalar(xgb_prediction_next_day),
+                )
                 
             except Exception as e:
-                print(f"Error making predictions for {ticker}: {str(e)}")
+                trace_event(
+                    "pipeline.prediction_exception",
+                    ticker=ticker,
+                    error_type=type(e).__name__,
+                    error=str(e),
+                )
                 continue
 
         except Exception as e:
+            trace_event(
+                "pipeline.ticker_exception",
+                ticker=ticker,
+                error_type=type(e).__name__,
+                error=str(e),
+            )
             print(f"\nError processing {ticker}:")
             print(f"Error type: {type(e).__name__}")
             print(f"Error message: {str(e)}")
@@ -230,8 +262,11 @@ def execute_pipeline(tickers):
             print(f"Last successful operation: {traceback.extract_tb(e.__traceback__)[-1].name}")
             
     # Log the final state of predictions
-    print(f"DEBUG: Predictions - Close Predictions: {todays_close_predictions}")
-    print(f"DEBUG: Predictions - Next Day Close Predictions: {next_days_close_predictions}")
+    trace_event(
+        "pipeline.exit",
+        close_predictions=todays_close_predictions,
+        next_day_predictions=next_days_close_predictions,
+    )
     return predictions
 
 def make_prediction(features, model, X_scaler, y_scaler):

--- a/render_helpers.py
+++ b/render_helpers.py
@@ -2,6 +2,7 @@ import yfinance as yf
 import streamlit as st
 import streamlit.components.v1 as components
 from utils import market_status
+from trace_utils import trace_event
 
 
 THEME = {
@@ -402,47 +403,50 @@ def search_and_add_ticker(new_ticker):
     # This way it doesn't keep appearing in the search bar after it's been removed
     if new_ticker != st.session_state.new_ticker:
         st.session_state.new_ticker = new_ticker
-        print(f"[SEARCH] new_ticker state updated -> {new_ticker}")
+        trace_event("search.state_updated", new_ticker=new_ticker)
 
     if new_ticker:
         try:
-            print(
-                f"[SEARCH] checking ticker={new_ticker!r} "
-                f"selected={st.session_state.get('selected_tickers', [])} "
-                f"all={st.session_state.get('tickers', [])}"
+            trace_event(
+                "search.enter",
+                new_ticker=new_ticker,
+                selected=st.session_state.get("selected_tickers", []),
+                tickers=st.session_state.get("tickers", []),
             )
             stock_data = get_recent_data(new_ticker)
             if stock_data is None or stock_data.empty:
-                print(f"[SEARCH] ticker invalid or empty: {new_ticker!r}")
+                trace_event("search.invalid_or_empty", new_ticker=new_ticker)
                 st.warning(f"Ticker '{new_ticker}' is not valid or does not exist.")
             else:
                 new_ticker_upper = new_ticker.upper()
                 if new_ticker_upper not in [
                     t.upper() for t in st.session_state.tickers
                 ]:
-                    print(f"[SEARCH] adding new ticker to list: {new_ticker_upper}")
+                    trace_event("search.add_new_ticker", ticker=new_ticker_upper)
                     st.session_state.tickers.insert(0, new_ticker_upper)
                     st.session_state.selected_tickers.append(new_ticker_upper)
-                    print(
-                        f"[SEARCH] rerun after add. "
-                        f"selected={st.session_state.selected_tickers} "
-                        f"tickers={st.session_state.tickers}"
+                    trace_event(
+                        "search.rerun",
+                        reason="added_new_ticker",
+                        selected=st.session_state.selected_tickers,
+                        tickers=st.session_state.tickers,
                     )
                     st.rerun()
                 else:
                     if new_ticker_upper not in [
                         t.upper() for t in st.session_state.selected_tickers
                     ]:
-                        print(f"[SEARCH] ticker already known; selecting it: {new_ticker_upper}")
+                        trace_event("search.select_existing_ticker", ticker=new_ticker_upper)
                         st.session_state.selected_tickers.append(new_ticker_upper)
-                        print(
-                            f"[SEARCH] rerun after select. "
-                            f"selected={st.session_state.selected_tickers} "
-                            f"tickers={st.session_state.tickers}"
+                        trace_event(
+                            "search.rerun",
+                            reason="selected_existing_ticker",
+                            selected=st.session_state.selected_tickers,
+                            tickers=st.session_state.tickers,
                         )
                         st.rerun()
                     else:
-                        print(f"[SEARCH] ticker already selected; no rerun: {new_ticker_upper}")
+                        trace_event("search.already_selected", ticker=new_ticker_upper)
         except Exception as e:
-            print(f"[SEARCH] exception while adding ticker {new_ticker!r}: {e}")
+            trace_event("search.exception", new_ticker=new_ticker, error=str(e))
             st.error(f"Error: {e}")

--- a/render_helpers.py
+++ b/render_helpers.py
@@ -402,25 +402,47 @@ def search_and_add_ticker(new_ticker):
     # This way it doesn't keep appearing in the search bar after it's been removed
     if new_ticker != st.session_state.new_ticker:
         st.session_state.new_ticker = new_ticker
+        print(f"[SEARCH] new_ticker state updated -> {new_ticker}")
 
     if new_ticker:
         try:
+            print(
+                f"[SEARCH] checking ticker={new_ticker!r} "
+                f"selected={st.session_state.get('selected_tickers', [])} "
+                f"all={st.session_state.get('tickers', [])}"
+            )
             stock_data = get_recent_data(new_ticker)
             if stock_data is None or stock_data.empty:
+                print(f"[SEARCH] ticker invalid or empty: {new_ticker!r}")
                 st.warning(f"Ticker '{new_ticker}' is not valid or does not exist.")
             else:
                 new_ticker_upper = new_ticker.upper()
                 if new_ticker_upper not in [
                     t.upper() for t in st.session_state.tickers
                 ]:
+                    print(f"[SEARCH] adding new ticker to list: {new_ticker_upper}")
                     st.session_state.tickers.insert(0, new_ticker_upper)
                     st.session_state.selected_tickers.append(new_ticker_upper)
+                    print(
+                        f"[SEARCH] rerun after add. "
+                        f"selected={st.session_state.selected_tickers} "
+                        f"tickers={st.session_state.tickers}"
+                    )
                     st.rerun()
                 else:
                     if new_ticker_upper not in [
                         t.upper() for t in st.session_state.selected_tickers
                     ]:
+                        print(f"[SEARCH] ticker already known; selecting it: {new_ticker_upper}")
                         st.session_state.selected_tickers.append(new_ticker_upper)
+                        print(
+                            f"[SEARCH] rerun after select. "
+                            f"selected={st.session_state.selected_tickers} "
+                            f"tickers={st.session_state.tickers}"
+                        )
                         st.rerun()
+                    else:
+                        print(f"[SEARCH] ticker already selected; no rerun: {new_ticker_upper}")
         except Exception as e:
+            print(f"[SEARCH] exception while adding ticker {new_ticker!r}: {e}")
             st.error(f"Error: {e}")

--- a/render_helpers.py
+++ b/render_helpers.py
@@ -407,18 +407,28 @@ def search_and_add_ticker(new_ticker):
 
     if new_ticker:
         try:
+            new_ticker_upper = new_ticker.strip().upper()
+            if not new_ticker_upper:
+                trace_event("search.invalid_or_empty", new_ticker=new_ticker)
+                return
+
+            if st.session_state.get("last_processed_ticker_search") == new_ticker_upper:
+                trace_event("search.skip_already_processed", ticker=new_ticker_upper)
+                return
+
             trace_event(
                 "search.enter",
                 new_ticker=new_ticker,
                 selected=st.session_state.get("selected_tickers", []),
                 tickers=st.session_state.get("tickers", []),
             )
-            stock_data = get_recent_data(new_ticker)
+            stock_data = get_recent_data(new_ticker_upper)
             if stock_data is None or stock_data.empty:
                 trace_event("search.invalid_or_empty", new_ticker=new_ticker)
+                st.session_state.last_processed_ticker_search = new_ticker_upper
                 st.warning(f"Ticker '{new_ticker}' is not valid or does not exist.")
             else:
-                new_ticker_upper = new_ticker.upper()
+                st.session_state.last_processed_ticker_search = new_ticker_upper
                 if new_ticker_upper not in [
                     t.upper() for t in st.session_state.tickers
                 ]:
@@ -426,12 +436,11 @@ def search_and_add_ticker(new_ticker):
                     st.session_state.tickers.insert(0, new_ticker_upper)
                     st.session_state.selected_tickers.append(new_ticker_upper)
                     trace_event(
-                        "search.rerun",
+                        "search.state_mutated",
                         reason="added_new_ticker",
                         selected=st.session_state.selected_tickers,
                         tickers=st.session_state.tickers,
                     )
-                    st.rerun()
                 else:
                     if new_ticker_upper not in [
                         t.upper() for t in st.session_state.selected_tickers
@@ -439,12 +448,11 @@ def search_and_add_ticker(new_ticker):
                         trace_event("search.select_existing_ticker", ticker=new_ticker_upper)
                         st.session_state.selected_tickers.append(new_ticker_upper)
                         trace_event(
-                            "search.rerun",
+                            "search.state_mutated",
                             reason="selected_existing_ticker",
                             selected=st.session_state.selected_tickers,
                             tickers=st.session_state.tickers,
                         )
-                        st.rerun()
                     else:
                         trace_event("search.already_selected", ticker=new_ticker_upper)
         except Exception as e:

--- a/render_ui.py
+++ b/render_ui.py
@@ -227,6 +227,14 @@ def render_ui():
                 valid_tickers=valid_tickers,
             )
             del st.session_state[widget_key]
+        elif list(current_widget_value) != selected_tickers:
+            trace_event(
+                "render_ui.delete_stale_widget_state",
+                widget_key=widget_key,
+                widget_value=current_widget_value,
+                selected_tickers=selected_tickers,
+            )
+            del st.session_state[widget_key]
 
     # Add warning if max tickers limit is reached
     if len(st.session_state.selected_tickers) >= UI_RULES["max_tickers"]:

--- a/render_ui.py
+++ b/render_ui.py
@@ -15,6 +15,7 @@ from rules import UI_RULES
 from display_market_status import display_market_status, generate_next_day_header
 from utils import market_status, next_trading_day
 from data_handler import debug_yfinance_cache_location, invalidate_yfinance_cache
+from trace_utils import trace_event
 
 
 def enforce_max_tickers():
@@ -173,6 +174,13 @@ def update_selected_tickers(change):
 
 
 def render_ui():
+    trace_event(
+        "render_ui.enter",
+        selected=st.session_state.get("selected_tickers"),
+        tickers=st.session_state.get("tickers"),
+        new_ticker=st.session_state.get("new_ticker"),
+        run_prediction=st.session_state.get("run_prediction"),
+    )
     st.title("Stock Price Predictor")
 
     with st.expander("Cache Debug", expanded=False):
@@ -183,8 +191,10 @@ def render_ui():
             st.code(str(cache_dir))
 
         if st.button("Clear yfinance cache now", key="clear_yf_cache_now"):
+            trace_event("render_ui.cache_clear_clicked")
             invalidate_yfinance_cache()
             st.success("yfinance cache cleared. The next request will rebuild it.")
+            trace_event("render_ui.rerun", reason="cache_clear")
             st.rerun()
 
     # Initialize default tickers if not already in session state
@@ -210,6 +220,12 @@ def render_ui():
         if not isinstance(current_widget_value, list) or any(
             item not in valid_tickers for item in current_widget_value
         ):
+            trace_event(
+                "render_ui.delete_invalid_widget_state",
+                widget_key=widget_key,
+                value=current_widget_value,
+                valid_tickers=valid_tickers,
+            )
             del st.session_state[widget_key]
 
     # Add warning if max tickers limit is reached
@@ -228,6 +244,7 @@ def render_ui():
 
     # Update selected tickers based on multiselect
     st.session_state.selected_tickers = tickers
+    trace_event("render_ui.after_multiselect", selected=tickers)
 
     # Search bar for new tickers
     new_ticker = st.text_input(
@@ -239,10 +256,19 @@ def render_ui():
     # This clears out the ticker if there's a change in removing the ticker
     # this way it doesn't keep appearing in the search bar after it's been removed
     if new_ticker != st.session_state.new_ticker:
+        trace_event(
+            "render_ui.new_ticker_changed",
+            previous=st.session_state.new_ticker,
+            current=new_ticker,
+        )
         st.session_state.new_ticker = new_ticker
 
     if new_ticker:
+        trace_event("render_ui.before_search_and_add", new_ticker=new_ticker)
         search_and_add_ticker(new_ticker)
+        trace_event("render_ui.after_search_and_add", new_ticker=new_ticker)
+    if st.session_state.new_ticker:
+        trace_event("render_ui.clear_new_ticker", value=st.session_state.new_ticker)
     st.session_state.new_ticker = ""
 
     # Create two distinct containers
@@ -258,12 +284,19 @@ def render_ui():
 
     if predict_button:
         # Set a flag in session state to indicate prediction is requested
-        print(
-            f"[PREDICT] button clicked. "
-            f"selected={st.session_state.get('selected_tickers', [])} "
-            f"tickers={st.session_state.get('tickers', [])} "
-            f"new_ticker={st.session_state.get('new_ticker', '')!r}"
+        trace_event(
+            "render_ui.predict_clicked",
+            selected=st.session_state.get("selected_tickers", []),
+            tickers=st.session_state.get("tickers", []),
+            new_ticker=st.session_state.get("new_ticker", ""),
         )
         st.session_state.run_prediction = True
         # Trigger a rerun to allow the controller to execute the pipeline
+        trace_event("render_ui.rerun", reason="predict_clicked")
         st.rerun()
+    trace_event(
+        "render_ui.exit",
+        selected=st.session_state.get("selected_tickers"),
+        new_ticker=st.session_state.get("new_ticker"),
+        run_prediction=st.session_state.get("run_prediction"),
+    )

--- a/render_ui.py
+++ b/render_ui.py
@@ -258,6 +258,12 @@ def render_ui():
 
     if predict_button:
         # Set a flag in session state to indicate prediction is requested
+        print(
+            f"[PREDICT] button clicked. "
+            f"selected={st.session_state.get('selected_tickers', [])} "
+            f"tickers={st.session_state.get('tickers', [])} "
+            f"new_ticker={st.session_state.get('new_ticker', '')!r}"
+        )
         st.session_state.run_prediction = True
         # Trigger a rerun to allow the controller to execute the pipeline
         st.rerun()

--- a/stock_predictors.py
+++ b/stock_predictors.py
@@ -4,40 +4,76 @@ from render_ui import render_ui, display_results
 from pipeline import execute_pipeline
 from session_state import initialize_session_state
 from data_handler import debug_yfinance_cache_location
+from trace_utils import trace_event
 
 def main():
     # Initialize session state
     initialize_session_state()
+    st.session_state.trace_pass = st.session_state.get("trace_pass", 0) + 1
+    trace_event(
+        "main.enter",
+        pass_no=st.session_state.trace_pass,
+        run_prediction=st.session_state.get("run_prediction"),
+        selected=st.session_state.get("selected_tickers"),
+        tickers=st.session_state.get("tickers"),
+        new_ticker=st.session_state.get("new_ticker"),
+        has_last_predictions=st.session_state.get("last_predictions") is not None,
+    )
     debug_yfinance_cache_location()
 
     # Render UI immediately after initialization
+    trace_event("main.before_render_ui", pass_no=st.session_state.trace_pass)
     render_ui()
+    trace_event(
+        "main.after_render_ui",
+        pass_no=st.session_state.trace_pass,
+        run_prediction=st.session_state.get("run_prediction"),
+        selected=st.session_state.get("selected_tickers"),
+        new_ticker=st.session_state.get("new_ticker"),
+        has_last_predictions=st.session_state.get("last_predictions") is not None,
+    )
 
     # Check if prediction should be run
     if hasattr(st.session_state, 'run_prediction') and st.session_state.run_prediction:
+        trace_event("main.prediction_requested", pass_no=st.session_state.trace_pass)
         # Reset the flag
         st.session_state.run_prediction = False
 
         # Increment the key to force new containers on next render
         st.session_state.results_key += 1
+        trace_event(
+            "main.prediction_state_reset",
+            pass_no=st.session_state.trace_pass,
+            results_key=st.session_state.results_key,
+        )
 
         # Wait for 2 seconds
         time_module.sleep(2)
 
         # Get selected tickers
         tickers = st.session_state.selected_tickers
+        trace_event("main.before_execute_pipeline", tickers=tickers)
 
         # Execute pipeline
         predictions = execute_pipeline(tickers)
+        trace_event(
+            "main.after_execute_pipeline",
+            close_count=len(predictions[0]) if predictions else None,
+            next_count=len(predictions[1]) if predictions else None,
+        )
 
         # Cache predictions
         st.session_state.last_predictions = predictions
 
         # Display results
+        trace_event("main.before_display_results", source="fresh_prediction")
         display_results(predictions)
     elif st.session_state.get('last_predictions') is not None:
         # Re-render cached predictions
+        trace_event("main.before_display_results", source="cached_prediction")
         display_results(st.session_state.last_predictions)
+    else:
+        trace_event("main.idle", pass_no=st.session_state.trace_pass)
 
 # Run the main function
 if __name__ == "__main__":

--- a/trace_utils.py
+++ b/trace_utils.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timezone
+import os
+import threading
+
+
+def trace_event(event, **fields):
+    """Emit one structured control-flow line for Render logs."""
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+    details = " ".join(
+        f"{key}={_compact(value)}" for key, value in fields.items()
+    )
+    print(
+        f"[TRACE] ts={timestamp} pid={os.getpid()} "
+        f"thread={threading.current_thread().name} event={event} {details}",
+        flush=True,
+    )
+
+
+def _compact(value):
+    text = repr(value)
+    if len(text) > 300:
+        return text[:297] + "..."
+    return text


### PR DESCRIPTION
## Summary
- add structured `[TRACE]` logs around Streamlit control flow, yfinance cache state, downloads, and pipeline execution
- stop the ticker search path from calling `st.rerun()` repeatedly
- preserve searched ticker selections by clearing stale multiselect widget state
- keep yfinance cache invalidation/retry support for retryable failures and manual cache clearing
- merge current main skipped-ticker handling with the Render debug fixes

## Root Cause
The apparent yfinance/cache loop was primarily a Streamlit rerun loop: the search box retained the submitted ticker, `search_and_add_ticker()` selected it again, and the helper called `st.rerun()` repeatedly. After removing that rerun, the next issue was stale multiselect widget state overwriting the searched ticker selection before Predict.

## Validation
- `python -m py_compile data_handler.py pipeline.py render_helpers.py render_ui.py stock_predictors.py trace_utils.py`
- deployed and tested on Render debug branch
- Playwright exercised `https://stockpredictors.onrender.com`: searched `TSLA`, clicked Predict
- Render logs confirmed `main.before_execute_pipeline tickers=['AAPL', 'GOOGL', 'MSFT', 'TSLA']`
- Render logs confirmed `yfinance.download.finish ticker='TSLA' empty=False rows=4016`
- Render logs confirmed `pipeline.prediction_finish ticker='TSLA'`
- no latest `yfinance.cache_error` entries were observed
