### PR TITLE
fix: search autoselect, clear bar, loading status, UX tweaks

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -53,7 +53,7 @@ def execute_pipeline(tickers):
     skipped_tickers = []  # Track tickers that couldn't be processed
 
     for ticker in tickers:
-        st.markdown(f"Processing {ticker}...")
+        st.write(f"⏳ Fetching & training **{ticker}**...")
         trace_event("pipeline.ticker_start", ticker=ticker)
 
         try:

--- a/render_helpers.py
+++ b/render_helpers.py
@@ -399,8 +399,9 @@ def ticker_header_html(ticker, theme_name=None):
 
 
 def search_and_add_ticker(new_ticker):
-    # Clears out the ticker if there's a change in removing the ticker
-    # This way it doesn't keep appearing in the search bar after it's been removed
+    # Returns True  → ticker added/selected: caller should clear bar and rerun
+    # Returns None  → guard fired (already processed): caller should clear bar, no forced rerun
+    # Returns False → invalid/empty: keep bar so user sees warning
     if new_ticker != st.session_state.new_ticker:
         st.session_state.new_ticker = new_ticker
         trace_event("search.state_updated", new_ticker=new_ticker)
@@ -410,11 +411,11 @@ def search_and_add_ticker(new_ticker):
             new_ticker_upper = new_ticker.strip().upper()
             if not new_ticker_upper:
                 trace_event("search.invalid_or_empty", new_ticker=new_ticker)
-                return
+                return False
 
             if st.session_state.get("last_processed_ticker_search") == new_ticker_upper:
                 trace_event("search.skip_already_processed", ticker=new_ticker_upper)
-                return
+                return None
 
             trace_event(
                 "search.enter",
@@ -427,6 +428,7 @@ def search_and_add_ticker(new_ticker):
                 trace_event("search.invalid_or_empty", new_ticker=new_ticker)
                 st.session_state.last_processed_ticker_search = new_ticker_upper
                 st.warning(f"Ticker '{new_ticker}' is not valid or does not exist.")
+                return False
             else:
                 st.session_state.last_processed_ticker_search = new_ticker_upper
                 if new_ticker_upper not in [
@@ -455,6 +457,9 @@ def search_and_add_ticker(new_ticker):
                         )
                     else:
                         trace_event("search.already_selected", ticker=new_ticker_upper)
+                return True
         except Exception as e:
             trace_event("search.exception", new_ticker=new_ticker, error=str(e))
             st.error(f"Error: {e}")
+            return False
+    return False

--- a/render_ui.py
+++ b/render_ui.py
@@ -211,17 +211,13 @@ def render_ui():
         st.session_state.tickers = UI_RULES["default_tickers"]
 
     if "selected_tickers" not in st.session_state:
-        st.session_state.selected_tickers = UI_RULES["default_tickers"].copy()
+        st.session_state.selected_tickers = []
 
     valid_tickers = list(st.session_state.tickers)
     selected_tickers = [
         ticker for ticker in st.session_state.selected_tickers if ticker in valid_tickers
     ]
-    if not selected_tickers:
-        selected_tickers = UI_RULES["default_tickers"].copy()
-        st.session_state.selected_tickers = selected_tickers
-    else:
-        st.session_state.selected_tickers = selected_tickers
+    st.session_state.selected_tickers = selected_tickers
 
     widget_key = "stock_multiselect"
     if widget_key in st.session_state:
@@ -257,6 +253,7 @@ def render_ui():
         on_change=update_selected_tickers,
         args=[widget_key],
         max_selections=UI_RULES["max_tickers"],
+        placeholder="Choose from the list or search below (e.g. TSLA, AAPL, GOOGL...)",
     )
 
     # Update selected tickers based on multiselect

--- a/render_ui.py
+++ b/render_ui.py
@@ -263,15 +263,16 @@ def render_ui():
     st.session_state.selected_tickers = tickers
     trace_event("render_ui.after_multiselect", selected=tickers)
 
-    # Search bar for new tickers
+    # Search bar — keyed by counter so incrementing counter creates a fresh widget (clears input).
+    # Streamlit cannot reset a widget's value mid-run via session_state assignment or key deletion;
+    # changing the key is the only reliable approach.
+    search_key = f"new_ticker_input_{st.session_state.search_input_counter}"
     new_ticker = st.text_input(
         "Search for a stock ticker:",
-        value=st.session_state.new_ticker,
-        key="new_ticker_input",
+        value="",
+        key=search_key,
     )
 
-    # This clears out the ticker if there's a change in removing the ticker
-    # this way it doesn't keep appearing in the search bar after it's been removed
     if new_ticker != st.session_state.new_ticker:
         trace_event(
             "render_ui.new_ticker_changed",
@@ -285,16 +286,13 @@ def render_ui():
         search_result = search_and_add_ticker(new_ticker)
         trace_event("render_ui.after_search_and_add", new_ticker=new_ticker, result=str(search_result))
         if search_result is True:
-            # Ticker added/selected: delete widget key so text_input re-renders empty, then rerun
-            # so multiselect picks up updated selected_tickers on the fresh render cycle.
-            if "new_ticker_input" in st.session_state:
-                del st.session_state["new_ticker_input"]
+            # Increment counter → next render gets a new key → fresh empty widget.
+            st.session_state.search_input_counter += 1
             st.session_state.new_ticker = ""
             st.rerun()
         elif search_result is None:
-            # Guard fired (already processed): clear bar without forcing a rerun
-            if "new_ticker_input" in st.session_state:
-                del st.session_state["new_ticker_input"]
+            # Guard fired: clear bar without forcing a rerun
+            st.session_state.search_input_counter += 1
             st.session_state.new_ticker = ""
         # search_result is False (invalid ticker): leave bar so user sees the warning
     if st.session_state.new_ticker:

--- a/render_ui.py
+++ b/render_ui.py
@@ -282,8 +282,21 @@ def render_ui():
 
     if new_ticker:
         trace_event("render_ui.before_search_and_add", new_ticker=new_ticker)
-        search_and_add_ticker(new_ticker)
-        trace_event("render_ui.after_search_and_add", new_ticker=new_ticker)
+        search_result = search_and_add_ticker(new_ticker)
+        trace_event("render_ui.after_search_and_add", new_ticker=new_ticker, result=str(search_result))
+        if search_result is True:
+            # Ticker added/selected: delete widget key so text_input re-renders empty, then rerun
+            # so multiselect picks up updated selected_tickers on the fresh render cycle.
+            if "new_ticker_input" in st.session_state:
+                del st.session_state["new_ticker_input"]
+            st.session_state.new_ticker = ""
+            st.rerun()
+        elif search_result is None:
+            # Guard fired (already processed): clear bar without forcing a rerun
+            if "new_ticker_input" in st.session_state:
+                del st.session_state["new_ticker_input"]
+            st.session_state.new_ticker = ""
+        # search_result is False (invalid ticker): leave bar so user sees the warning
     if st.session_state.new_ticker:
         trace_event("render_ui.clear_new_ticker", value=st.session_state.new_ticker)
     st.session_state.new_ticker = ""

--- a/session_state.py
+++ b/session_state.py
@@ -16,6 +16,9 @@ def initialize_session_state():
     if 'new_ticker' not in st.session_state:
         st.session_state.new_ticker = ''
 
+    if 'search_input_counter' not in st.session_state:
+        st.session_state.search_input_counter = 0
+
     if 'run_prediction' not in st.session_state:
         st.session_state.run_prediction = False
 

--- a/stock_predictors.py
+++ b/stock_predictors.py
@@ -1,5 +1,4 @@
 import streamlit as st
-import time as time_module
 from render_ui import render_ui, display_results
 from pipeline import execute_pipeline
 from session_state import initialize_session_state
@@ -47,15 +46,18 @@ def main():
             results_key=st.session_state.results_key,
         )
 
-        # Wait for 2 seconds
-        time_module.sleep(2)
-
         # Get selected tickers
         tickers = st.session_state.selected_tickers
         trace_event("main.before_execute_pipeline", tickers=tickers)
 
-        # Execute pipeline
-        predictions, skipped_tickers = execute_pipeline(tickers)
+        # Execute pipeline with per-ticker loading status
+        with st.status("Running predictions...", expanded=True) as status:
+            predictions, skipped_tickers = execute_pipeline(tickers)
+            status.update(
+                label=f"Predictions ready for {', '.join(tickers)}",
+                state="complete",
+                expanded=False,
+            )
         trace_event(
             "main.after_execute_pipeline",
             close_count=len(predictions[0]) if predictions else None,


### PR DESCRIPTION
## Summary

- **Auto-select on search**: typing a ticker and pressing Enter now immediately selects it in the multiselect — previously required a second search. Root cause: multiselect renders before `search_and_add_ticker` runs; fix uses `st.rerun()` after adding so the multiselect re-renders with updated `selected_tickers` in the same cycle.
- **Search bar clears after add**: counter key pattern (`search_input_counter`) forces a fresh widget on the next render — `del`/assignment approaches both fail because Streamlit uses the browser's last value on programmatic reruns.
- **Per-ticker loading status**: `execute_pipeline` now runs inside `st.status`, showing `⏳ Fetching & training TICKER...` per ticker, collapsing to a done summary on completion.
- **No default pre-selected tickers**: app starts with an empty multiselect instead of AAPL/GOOGL/MSFT.
- **Multiselect hint text**: placeholder guides users to search (e.g. TSLA, AAPL, GOOGL...).

## Test plan

- [ ] Search a ticker → auto-selected in multiselect, bar clears — one interaction
- [ ] Search invalid ticker → warning shows, bar keeps text
- [ ] Search same ticker twice → second search clears bar, no rerun loop
- [ ] App start → multiselect empty with hint text
- [ ] Hit Predict → st.status loading panel shows per-ticker progress, collapses when done
- [ ] Playwright: `python test_search_ui.py` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)