### PR TITLE
feat: uniform card spacing — match today and next-day sections

### DIFF
--- a/render_ui.py
+++ b/render_ui.py
@@ -58,7 +58,7 @@ def display_results(predictions, skipped_tickers=None):
 
     # Display skipped tickers with messages
     for ticker, reason in skipped_tickers:
-        with render_section_container(f"ticker_section_{ticker}_skipped", "dark"):
+        with render_section_container(f"ticker_section_{ticker}_skipped", "dark", padding_bottom=28, margin_bottom=20):
             st.markdown(ticker_header_html(ticker, "dark"), unsafe_allow_html=True)
             st.warning(f"⚠️ Insufficient historical data for {ticker} — need more trading days to generate predictions")
 
@@ -100,7 +100,7 @@ def display_results(predictions, skipped_tickers=None):
 
             theme = st.session_state.get("theme", "dark")
 
-            with render_section_container(f"ticker_section_{ticker}", theme):
+            with render_section_container(f"ticker_section_{ticker}", theme, padding_bottom=28, margin_bottom=20):
                 # Section header with ticker and bar
                 st.markdown(ticker_header_html(ticker, theme), unsafe_allow_html=True)
 


### PR DESCRIPTION
## Summary
- All section containers (`ticker_section`, `ticker_section_skipped`, `next_day_section`) now use `padding_bottom=28, margin_bottom=20`
- Today's grouping cards now have identical bottom spacing to the next-day card
- `render_section_container` and `section_container_css` gained optional `padding_bottom`/`margin_bottom` params (defaults preserve pre-existing behaviour)

## Test plan
- [ ] Predict on one or more tickers
- [ ] Confirm bottom padding inside each card looks consistent (today and next-day sections match)
- [ ] Confirm gap below each outer card is uniform down the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)