### PR TITLE
fix: show ticker validation spinner

### DIFF
--- a/render_ui.py
+++ b/render_ui.py
@@ -303,7 +303,8 @@ def render_ui():
 
     if new_ticker:
         trace_event("render_ui.before_search_and_add", new_ticker=new_ticker)
-        search_result = search_and_add_ticker(new_ticker)
+        with st.spinner("Checking ticker..."):
+            search_result = search_and_add_ticker(new_ticker)
         trace_event("render_ui.after_search_and_add", new_ticker=new_ticker, result=str(search_result))
         if search_result is True:
             # Increment counters → next render gets fresh widgets. This keeps


### PR DESCRIPTION
## Summary
- Show a friendly Streamlit spinner while the app validates a searched ticker before adding it to the multiselect.
- Spinner copy is intentionally short: `Checking ticker...`.

## User Impact
Users get immediate feedback while yfinance validation is running, especially when the provider is slow or rate-limited.

## Validation
- `venv\\Scripts\\python.exe -m py_compile render_ui.py render_helpers.py session_state.py`
- `venv\\Scripts\\python.exe -m pytest -q`
- Result: `103 passed`
