### PR TITLE
fix: surface yfinance provider outages safely

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -19,7 +19,11 @@ _YF_RETRY_ERROR_MARKERS = (
     "failed download",
     "yfr",
     "runtimeerror",
+    "rate limit",
+    "rate-limit",
+    "too many requests",
 )
+YFINANCE_PROVIDER_DOWN_MESSAGE = "yfinance data provider is down, please try later"
 
 
 def _default_yfinance_cache_dir():
@@ -152,6 +156,28 @@ def _should_refresh_after_download(ticker, df):
             error=error_text,
         )
     return should_refresh
+
+
+def yfinance_provider_error_text(ticker=None, exc=None):
+    """
+    Return yfinance provider/rate-limit error text when the latest failure looks
+    external to the app. Used for user-facing messages without blocking search.
+    """
+    parts = []
+    if exc is not None:
+        parts.append(f"{type(exc).__name__}: {exc}")
+
+    if ticker is not None and hasattr(yf_shared, "_ERRORS"):
+        parts.append(str(yf_shared._ERRORS.get(str(ticker).upper(), "")))
+
+    error_text = " ".join(part for part in parts if part).lower()
+    if any(marker in error_text for marker in _YF_RETRY_ERROR_MARKERS):
+        return error_text
+    return ""
+
+
+def is_yfinance_provider_down(ticker=None, exc=None):
+    return bool(yfinance_provider_error_text(ticker, exc))
 
 
 def invalidate_yfinance_cache():

--- a/pipeline.py
+++ b/pipeline.py
@@ -5,7 +5,11 @@ import time as time_module
 from datetime import timedelta
 from sklearn.metrics import mean_absolute_error, mean_squared_error
 from utils import get_nyse_date, market_status, get_nyse_datetime, get_last_row
-from data_handler import fetch_data
+from data_handler import (
+    YFINANCE_PROVIDER_DOWN_MESSAGE,
+    fetch_data,
+    is_yfinance_provider_down,
+)
 from data_processor import preprocess_data
 from feature_engineering import add_technical_indicators, get_feature_columns
 from model import train_model
@@ -262,6 +266,10 @@ def execute_pipeline(tickers):
                 continue
 
         except Exception as e:
+            if is_yfinance_provider_down(ticker, e):
+                skipped_tickers.append((ticker, YFINANCE_PROVIDER_DOWN_MESSAGE))
+            else:
+                skipped_tickers.append((ticker, str(e)))
             trace_event(
                 "pipeline.ticker_exception",
                 ticker=ticker,

--- a/render_ui.py
+++ b/render_ui.py
@@ -14,7 +14,11 @@ from render_helpers import (
 from rules import UI_RULES
 from display_market_status import display_market_status, generate_next_day_header
 from utils import market_status, next_trading_day
-from data_handler import debug_yfinance_cache_location, invalidate_yfinance_cache
+from data_handler import (
+    YFINANCE_PROVIDER_DOWN_MESSAGE,
+    debug_yfinance_cache_location,
+    invalidate_yfinance_cache,
+)
 from trace_utils import trace_event
 
 
@@ -60,7 +64,10 @@ def display_results(predictions, skipped_tickers=None):
     for ticker, reason in skipped_tickers:
         with render_section_container(f"ticker_section_{ticker}_skipped", "dark", padding_bottom=28, margin_bottom=20):
             st.markdown(ticker_header_html(ticker, "dark"), unsafe_allow_html=True)
-            st.warning(f"⚠️ Insufficient historical data for {ticker} — need more trading days to generate predictions")
+            if reason == YFINANCE_PROVIDER_DOWN_MESSAGE:
+                st.error(reason)
+            else:
+                st.warning(f"Insufficient historical data for {ticker} - need more trading days to generate predictions")
 
     for ticker, predictions in grouped_predictions.items():
         try:
@@ -303,7 +310,8 @@ def render_ui():
 
     if new_ticker:
         trace_event("render_ui.before_search_and_add", new_ticker=new_ticker)
-        search_result = search_and_add_ticker(new_ticker)
+        with st.spinner("Checking ticker..."):
+            search_result = search_and_add_ticker(new_ticker)
         trace_event("render_ui.after_search_and_add", new_ticker=new_ticker, result=str(search_result))
         if search_result is True:
             # Increment counters → next render gets fresh widgets. This keeps

--- a/tests/test_yfinance_provider_status.py
+++ b/tests/test_yfinance_provider_status.py
@@ -1,0 +1,32 @@
+import data_handler
+
+
+def test_provider_down_detects_try_after_exception():
+    exc = RuntimeError("YFRateLimitError: Try after a while.")
+
+    assert data_handler.is_yfinance_provider_down("TSLA", exc)
+
+
+def test_provider_down_detects_shared_yfinance_error(monkeypatch):
+    monkeypatch.setattr(
+        data_handler.yf_shared,
+        "_ERRORS",
+        {"IBM": "Failed download: YFRateLimitError('Try after a while.')"},
+        raising=False,
+    )
+
+    assert data_handler.is_yfinance_provider_down("IBM")
+
+
+def test_provider_down_ignores_plain_invalid_ticker_error(monkeypatch):
+    monkeypatch.setattr(data_handler.yf_shared, "_ERRORS", {"FAKE": ""}, raising=False)
+    exc = ValueError("No data retrieved for ticker FAKE from yfinance")
+
+    assert not data_handler.is_yfinance_provider_down("FAKE", exc)
+
+
+def test_provider_down_message_text_is_stable():
+    assert (
+        data_handler.YFINANCE_PROVIDER_DOWN_MESSAGE
+        == "yfinance data provider is down, please try later"
+    )


### PR DESCRIPTION
## Summary
- Add a short `Checking ticker...` spinner while searched tickers are added to the list.
- Surface yfinance provider/rate-limit failures as `yfinance data provider is down, please try later` from the prediction/data-fetch path.
- Keep search/autoselect yfinance-independent so valid tickers are not blocked before prediction.
- Ensure ticker-level pipeline exceptions are visible as skipped ticker messages instead of making results appear to vanish.

## Root Cause / Safety Note
The prior validation attempt blocked search/autoselect by calling yfinance before adding a ticker. That could fail for valid tickers when yfinance was degraded. This version does not preflight validate searched tickers; it only classifies provider failures after the normal prediction fetch path sees a yfinance failure.

## Validation
- `venv\\Scripts\\python.exe -m py_compile data_handler.py pipeline.py render_ui.py render_helpers.py session_state.py`
- `venv\\Scripts\\python.exe -m pytest -q`
- Result: `102 passed`
- Local browser smoke: searched `TSLA`, searched `IBM`, clicked `Predict`, and predictions rendered for both.
