### PR TITLE
chore: remove cache debug from customer UI

### DIFF
--- a/render_ui.py
+++ b/render_ui.py
@@ -14,11 +14,7 @@ from render_helpers import (
 from rules import UI_RULES
 from display_market_status import display_market_status, generate_next_day_header
 from utils import market_status, next_trading_day
-from data_handler import (
-    YFINANCE_PROVIDER_DOWN_MESSAGE,
-    debug_yfinance_cache_location,
-    invalidate_yfinance_cache,
-)
+from data_handler import YFINANCE_PROVIDER_DOWN_MESSAGE
 from trace_utils import trace_event
 
 
@@ -218,20 +214,6 @@ def render_ui():
         run_prediction=st.session_state.get("run_prediction"),
     )
     st.title("Stock Price Predictor")
-
-    with st.expander("Cache Debug", expanded=False):
-        st.caption("Inspect or clear the yfinance cache without restarting the service.")
-        if st.button("Show yfinance cache path", key="show_yf_cache_path"):
-            cache_dir = debug_yfinance_cache_location()
-            st.success(f"Cache path: {cache_dir}")
-            st.code(str(cache_dir))
-
-        if st.button("Clear yfinance cache now", key="clear_yf_cache_now"):
-            trace_event("render_ui.cache_clear_clicked")
-            invalidate_yfinance_cache()
-            st.success("yfinance cache cleared. The next request will rebuild it.")
-            trace_event("render_ui.rerun", reason="cache_clear")
-            st.rerun()
 
     # Initialize default tickers if not already in session state
     if "tickers" not in st.session_state:

--- a/tests/test_customer_facing_ui.py
+++ b/tests/test_customer_facing_ui.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_cache_debug_controls_are_not_customer_facing():
+    source = Path("render_ui.py").read_text(encoding="utf-8")
+
+    assert "Cache Debug" not in source
+    assert "Show yfinance cache path" not in source
+    assert "Clear yfinance cache now" not in source


### PR DESCRIPTION
## Summary
- Remove the customer-facing `Cache Debug` expander from the Streamlit UI.
- Remove the visible cache path and cache clear buttons from `render_ui.py`.
- Keep backend yfinance cache utilities intact for ops/debug use.
- Add a regression test to prevent those debug controls from returning to the customer-facing UI.

## Validation
- `venv\\Scripts\\python.exe -m py_compile render_ui.py data_handler.py stock_predictors.py`
- `venv\\Scripts\\python.exe -m pytest -q`
- Result: `109 passed`
