### PR TITLE
Update market status subtitle message

### DIFF
--- a/display_market_status.py
+++ b/display_market_status.py
@@ -13,7 +13,7 @@ def generate_market_status_header(status, last_date_str, today_is_trading_day=Tr
       - BEFORE_MARKET_OPEN (trading day, pre-bell):
             "Market is Closed" / "Displaying Predictions for <last traded date>"
       - MARKET_OPEN:
-            "Market is Open" / "Live — Last Traded"
+            "Market is Open" / "Displaying Predictions for Today's Close"
       - AFTER_MARKET_CLOSE on a trading day (today's close is final):
             "Market is Closed" / "Today's Close Predictions and Actuals"
       - AFTER_MARKET_CLOSE on a weekend/holiday (today never traded):
@@ -27,7 +27,7 @@ def generate_market_status_header(status, last_date_str, today_is_trading_day=Tr
     subtitle = ""
     if status == "MARKET_OPEN":
         icon, title = "🔔", "Market is Open"
-        subtitle = "Live — Last Traded"
+        subtitle = "Displaying Predictions for Today's Close"
     elif status == "BEFORE_MARKET_OPEN":
         icon, title = "🔴", "Market is Closed"
         subtitle = f"Displaying Predictions for {last_date_str}"

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -7,7 +7,7 @@ Streamlit / no time dependence, so it is deterministic.
 
 State -> header copy:
   BEFORE_MARKET_OPEN          -> "Market is Closed" + date subtitle
-  MARKET_OPEN                 -> "Market is Open" + "Live - Last Traded" subtitle
+  MARKET_OPEN                 -> "Market is Open" + "Displaying Predictions for Today's Close" subtitle
   AFTER_MARKET_CLOSE, trading -> "Market is Closed" + finality subtitle
   AFTER_MARKET_CLOSE, off-day -> "Market is Closed (Weekend/Holiday)" + date subtitle
 """
@@ -35,7 +35,7 @@ def test_market_open_live_subtitle_no_date():
     html = generate_market_status_header("MARKET_OPEN", DATE)
     assert "🔔" in html
     assert "Market is Open" in html
-    assert "Live — Last Traded" in html
+    assert "Displaying Predictions for Today's Close" in html
     assert DATE not in html
 
 


### PR DESCRIPTION
Update the market status header subtitle to display 'Displaying Predictions for Today's Close' instead of 'Live - Last Traded' when the market is open.

This aligns the UI messaging with the predictions being displayed.