### PR TITLE
feat: training pipeline caching (CSV delta + model pkl)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ build/
 
 # Local cached ticker data (regenerated at runtime)
 *_data.csv
+
+# Trained model cache (regenerated at runtime)
+models/
+
+# Known tickers list (regenerated at runtime)
+known_tickers.json

--- a/CACHING_PLAN.md
+++ b/CACHING_PLAN.md
@@ -3,10 +3,10 @@
 ## Status
 | Item | Status |
 |------|--------|
-| CSV data cache (`fetch_data`) | 🔄 in progress |
-| Model cache (`train_model`) | 🔄 in progress |
-| `known_tickers.json` skip list | 🔄 in progress |
-| `models/` dir + gitignore | 🔄 in progress |
+| CSV data cache (`fetch_data`) | ✅ done — ba2ec42 |
+| Model cache (`train_model`) | ✅ done — ba2ec42 |
+| `known_tickers.json` skip list | ✅ done — ba2ec42 |
+| `models/` dir + gitignore | ✅ done — ba2ec42 |
 
 ---
 

--- a/CACHING_PLAN.md
+++ b/CACHING_PLAN.md
@@ -3,10 +3,10 @@
 ## Status
 | Item | Status |
 |------|--------|
-| CSV data cache (`fetch_data`) | ⬜ not started |
-| Model cache (`train_model`) | ⬜ not started |
-| `known_tickers.json` skip list | ⬜ not started |
-| `models/` dir + gitignore | ⬜ not started |
+| CSV data cache (`fetch_data`) | 🔄 in progress |
+| Model cache (`train_model`) | 🔄 in progress |
+| `known_tickers.json` skip list | 🔄 in progress |
+| `models/` dir + gitignore | 🔄 in progress |
 
 ---
 

--- a/CACHING_PLAN.md
+++ b/CACHING_PLAN.md
@@ -21,9 +21,10 @@
 - 30 s threshold applies on Predict click only, not background polling
 
 ### Model cache — `train_model()` at [model.py:10](model.py#L10)
-- After train: save model + scalers to `models/{ticker}_{date}_{model_type}.pkl` via joblib
-- On Predict: if same-calendar-day file exists → load, skip retrain
-- One retrain per ticker per calendar day max
+- After train: save model + scalers to `models/{ticker}_{last_data_date}_{model_type}_{target}.pkl` via joblib
+- Cache key = last row date of training data (not calendar date)
+- On Predict: pkl for current last-data-date exists → load, skip retrain
+- Retrain only when CSV gains new trading closes
 
 ### Ticker known-list — `known_tickers.json`
 - After successful data fetch: record ticker in `known_tickers.json`

--- a/CACHING_PLAN.md
+++ b/CACHING_PLAN.md
@@ -1,0 +1,57 @@
+# Caching Plan
+
+## Status
+| Item | Status |
+|------|--------|
+| CSV data cache (`fetch_data`) | ⬜ not started |
+| Model cache (`train_model`) | ⬜ not started |
+| `known_tickers.json` skip list | ⬜ not started |
+| `models/` dir + gitignore | ⬜ not started |
+
+---
+
+## Design decisions (locked 2026-06-17)
+
+### CSV data cache — `fetch_data()` at [data_handler.py:217](data_handler.py#L217)
+- First fetch: pull full history 2008→now, save `{ticker}_data.csv`
+- On Predict click: load CSV, check last row timestamp
+  - Last row age < 30 s → use CSV as-is
+  - Last row age ≥ 30 s → fetch delta since last row date, append to CSV
+- Historical rows are **immutable** — never re-fetch past data
+- 30 s threshold applies on Predict click only, not background polling
+
+### Model cache — `train_model()` at [model.py:10](model.py#L10)
+- After train: save model + scalers to `models/{ticker}_{date}_{model_type}.pkl` via joblib
+- On Predict: if same-calendar-day file exists → load, skip retrain
+- One retrain per ticker per calendar day max
+
+### Ticker known-list — `known_tickers.json`
+- After successful data fetch: record ticker in `known_tickers.json`
+- Skip yfinance validation calls for tickers already in the list
+
+---
+
+## Scope
+
+| File | Change |
+|------|--------|
+| [data_handler.py](data_handler.py) | `fetch_data()`: CSV save/load, delta fetch, staleness check |
+| [model.py](model.py) | `train_model()`: joblib save/load, same-day TTL check |
+| `models/` (new dir) | gitignore — not committed |
+| `known_tickers.json` (new) | gitignore or commit empty stub `{}` |
+
+---
+
+## Acceptance criteria
+- [ ] `AAPL` first Predict: fetches full history, writes CSV, trains model, writes pkl
+- [ ] `AAPL` second Predict (< 30 s): loads CSV as-is, loads pkl, no retrain
+- [ ] `AAPL` Predict after > 30 s: fetches delta only (not full history), appends CSV, loads pkl
+- [ ] New calendar day: same CSV used, model retrained, new pkl written
+- [ ] `known_tickers.json` written after first successful fetch
+- [ ] pytest -q green
+
+---
+
+## Follow-ups (post-implementation)
+- Cache eviction policy for old CSV / pkl files (none locked yet)
+- Cache location override via env var (nice-to-have)

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,117 +1,20 @@
-# Handoff
+# HANDOFF — StockPredictors
+Updated: 2026-06-17 | Branch: `main` @ `3404a86`
 
 ## Workspace
 - Path: `c:\Users\User\StockPredictors`
-- Date: 2026-06-17
-- Branch: `main` @ `4822edd` — local modifications to `.claude/settings.json`, `CLAUDE.md`, `HANDOFF.md`; untracked `graphify-out/`
-- Secondary worktree: `C:\Users\User\StockPredictors-market-status` on `investigate-market-status`
+- Production: `https://stockpredictors.onrender.com` (Render `srv-csvanmqj1k6c73c3dnt0`)
+- Secondary worktree: none active
 
----
-
-## Workflow rules (binding on next session)
-- **Manual test before commit/PR/merge** — verify each UI change in the live app before staging.
-- **New plan sections → dedicated `*_PLAN.md`** — `DARK_MODE_PLAN.md` archived at `archive/plans/`. Create a new plan file when the next feature scope grows.
-- **pytest -q green before merge** — every branch runs the full suite.
-
----
-
-## App shape / orientation
-
-| Item | Detail |
-|------|--------|
-| Entry point | [stock_predictors.py](stock_predictors.py) |
-| UI render | [render_ui.py](render_ui.py), [render_helpers.py](render_helpers.py) |
-| Session state | [session_state.py](session_state.py) |
-| Search logic | [render_helpers.py](render_helpers.py) `search_and_add_ticker` |
-| Data fetch | [data_handler.py](data_handler.py) `fetch_data()` at line 217 |
-| Model train | [model.py](model.py) `train_model()` at line 10 |
-| Plan doc | [UI_UX_PLAN.md](UI_UX_PLAN.md) — **status: Complete** |
-| Run (main) | `C:\Users\User\StockPredictors\venv\Scripts\streamlit.exe run stock_predictors.py` (port 8501) |
-| Run (worktree) | `-WorkingDirectory <worktree-path>` + port 8502+ |
-
----
-
-## Current state — all prior planned work done
-
-[UI_UX_PLAN.md](UI_UX_PLAN.md) is **Complete**. All §0–§7 visual/UX items, all dark mode items (DM1–DM6), search flow, card spacing, and production search regression — all merged and verified in production. No in-flight branches or worktrees.
-
----
-
-## Key domain facts (permanent)
-
-### Streamlit widget reset — counter key pattern
-`del`/assignment both fail to clear a text_input on programmatic reruns — browser value wins. Only reliable reset: increment `search_input_counter` in session state, use it in `key=`.
-
-### Streamlit multiselect auto-select
-Multiselect renders before `search_and_add_ticker`. `st.rerun()` after add is required for one-cycle sync.
-
-### `search_and_add_ticker` tri-state return
-- `True` — added/selected → increment counter + `st.rerun()`
-- `None` — guard fired → increment counter, no rerun
-- `False` — invalid → leave bar, warning visible
-
----
-
-## Next task — Training pipeline caching
-
-**Branch to create:** `training-cache`  
-**Create `CACHING_PLAN.md` at project root before coding.**
-
-### Design decisions (locked this session)
-
-**CSV data cache** — `fetch_data()` at [data_handler.py:217](data_handler.py#L217)
-- First fetch: pull full 2008→now, save `{ticker}_data.csv`
-- On Predict click: load CSV, check last row timestamp
-  - If last row age < 30s → use CSV as-is
-  - If last row age ≥ 30s → fetch delta since last row date, append to CSV
-- Historical rows are **immutable** — never re-fetch past data
-- 30s threshold is on Predict click only, not background polling
-
-**Model cache** — `train_model()` at [model.py:10](model.py#L10)
-- Save trained model + scalers to `models/{ticker}_{date}_{model_type}.pkl` after train
-- On Predict: if same-calendar-day file exists → load, skip retrain
-- One retrain per ticker per calendar day max
-
-**Ticker known-list**
-- After successful data fetch, record ticker in `known_tickers.json`
-- Skip yfinance validation calls for tickers already in the list
-
-### Scope: 3 files + 2 new artifacts
-- [data_handler.py](data_handler.py) — `fetch_data()` + incremental delta fetch logic
-- [model.py](model.py) — `train_model()` + joblib save/load wrapper
-- `models/` dir (new, gitignore)
-- `known_tickers.json` (new, gitignore or commit empty stub)
-
----
-
-## Possible future directions (after caching)
-- Prediction model improvements (accuracy, new models)
-- More tickers / data sources
-- Portfolio view / multi-ticker comparison
-- Deployment / production hardening
-
----
-
-## Locked decisions
-- Counter key (`search_input_counter`) — canonical Streamlit text_input reset.
-- `st.rerun()` after ticker add — required for multiselect sync.
-- `search_and_add_ticker` tri-state — `None` must not force rerun.
-- Dark mode default; toggle via `st.session_state.theme`.
-- CSV cache: 30s staleness on Predict click, delta-only fetch, historical immutable.
-- Model cache: same-day TTL, joblib, `models/` dir.
-
----
-
-## How to verify / run
-
+## Run commands
 ```powershell
-# Run main app
+# Main app
 & "C:\Users\User\StockPredictors\venv\Scripts\streamlit.exe" run stock_predictors.py
 
-# Run worktree app
+# Worktree app (port 8502+)
 Start-Process -FilePath "C:\Users\User\StockPredictors\venv\Scripts\streamlit.exe" `
   -ArgumentList "run","stock_predictors.py","--server.port","8502" `
-  -WorkingDirectory "C:\Users\User\<worktree-dir>" -WindowStyle Normal
+  -WorkingDirectory "C:\Users\User\StockPredictors-<branch>" -WindowStyle Normal
 
 # Kill a port
 netstat -ano | findstr ":<port>" | ForEach-Object { ($_ -split '\s+')[-1] } | Select-Object -Unique | ForEach-Object { Stop-Process -Id $_ -Force -ErrorAction SilentlyContinue }
@@ -124,3 +27,31 @@ $env:MARKET_NOW = "2026-06-17 10:00"   # open
 $env:MARKET_NOW = "2026-06-14 18:00"   # Saturday closed
 $env:MARKET_NOW = ""                    # clear
 ```
+
+## Key files
+| Role | File |
+|------|------|
+| Entry | [stock_predictors.py](stock_predictors.py) |
+| UI render | [render_ui.py](render_ui.py), [render_helpers.py](render_helpers.py) |
+| Session state | [session_state.py](session_state.py) |
+| Data fetch | [data_handler.py](data_handler.py) `fetch_data()` L217 |
+| Model train | [model.py](model.py) `train_model()` L10 |
+
+## Active branches
+| Branch | Plan doc | Status | Priority |
+|--------|----------|--------|----------|
+| training-cache | [CACHING_PLAN.md](CACHING_PLAN.md) | ⬜ not started | 1 — next |
+
+## Workflow rules
+- Manual test before commit/PR/merge — verify each UI change in the live app
+- pytest -q green before merge
+- Branch → PR → review → merge → delete (no direct commits to main)
+- New feature scope → dedicated `*_PLAN.md`
+
+## Locked decisions
+- Streamlit text_input reset: increment `search_input_counter` in session state, use in `key=`
+- `st.rerun()` after ticker add — required for multiselect one-cycle sync
+- `search_and_add_ticker` tri-state: `True` = added, `None` = guard fired (no rerun), `False` = invalid
+- Dark mode default; toggle via `st.session_state.theme`
+- Do not validate ticker with yfinance before selecting — prediction pipeline is source of truth
+- Use `pandas_market_calendars` / XNYS for trading-day checks, not clock time

--- a/data_handler.py
+++ b/data_handler.py
@@ -262,21 +262,25 @@ def fetch_data(ticker, end_date, start_date="2008-01-01", use_local_data=False):
 
         # Stale — delta fetch since last row date
         df = custom_read_csv(local_file)
-        last_date = df.index[-1]
-        delta_start = (last_date + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
-        trace_event("fetch_data.delta_start", ticker=ticker, delta_start=delta_start)
-        delta_df = _download_with_retry(ticker, delta_start, end_date)
-        if not delta_df.empty:
-            delta_df = _normalize_columns(delta_df)
-            df = pd.concat([df, delta_df])
-            df = df[~df.index.duplicated(keep="last")]
-            df.index.name = "Date"
-            df.to_csv(local_file)
-            trace_event("fetch_data.delta_saved", ticker=ticker, new_rows=len(delta_df))
+        if df.empty:
+            os.remove(local_file)
+            trace_event("fetch_data.corrupt_cache_removed", ticker=ticker)
         else:
-            trace_event("fetch_data.delta_empty", ticker=ticker)
-        _record_known_ticker(ticker)
-        return df
+            last_date = df.index[-1]
+            delta_start = (last_date + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+            trace_event("fetch_data.delta_start", ticker=ticker, delta_start=delta_start)
+            delta_df = _download_with_retry(ticker, delta_start, end_date)
+            if not delta_df.empty:
+                delta_df = _normalize_columns(delta_df)
+                df = pd.concat([df, delta_df])
+                df = df[~df.index.duplicated(keep="last")]
+                df.index.name = "Date"
+                df.to_csv(local_file)
+                trace_event("fetch_data.delta_saved", ticker=ticker, new_rows=len(delta_df))
+            else:
+                trace_event("fetch_data.delta_empty", ticker=ticker)
+            _record_known_ticker(ticker)
+            return df
 
     # No cache — full fetch
     trace_event("fetch_data.full_start", ticker=ticker, start_date=str(start_date), end_date=str(end_date))

--- a/data_handler.py
+++ b/data_handler.py
@@ -23,12 +23,13 @@ _YF_RETRY_ERROR_MARKERS = (
     "try after a while",
     "failed download",
     "yfr",
+    "yfratelimiterror",
     "runtimeerror",
     "rate limit",
     "rate-limit",
     "too many requests",
 )
-YFINANCE_PROVIDER_DOWN_MESSAGE = "yfinance data provider is down, please try later"
+YFINANCE_PROVIDER_DOWN_MESSAGE = "Data Provider yfinance is currently down. Please try again later."
 
 
 def _default_yfinance_cache_dir():

--- a/data_handler.py
+++ b/data_handler.py
@@ -2,10 +2,15 @@ import yfinance as yf
 import yfinance.shared as yf_shared
 import pandas as pd
 import os
+import time
+import json
 import threading
 from pathlib import Path
 import shutil
 from trace_utils import trace_event
+
+KNOWN_TICKERS_FILE = "known_tickers.json"
+_CACHE_FRESH_SECONDS = 30
 
 try:
     from yfinance import cache as yf_cache
@@ -187,6 +192,28 @@ def invalidate_yfinance_cache():
     clear_yfinance_cache()
     return True
 
+def _load_known_tickers():
+    if os.path.exists(KNOWN_TICKERS_FILE):
+        try:
+            with open(KNOWN_TICKERS_FILE) as f:
+                return set(json.load(f))
+        except Exception:
+            pass
+    return set()
+
+
+def _record_known_ticker(ticker):
+    known = _load_known_tickers()
+    if ticker not in known:
+        known.add(ticker)
+        with open(KNOWN_TICKERS_FILE, "w") as f:
+            json.dump(sorted(known), f)
+
+
+def is_known_ticker(ticker):
+    return ticker in _load_known_tickers()
+
+
 def custom_read_csv(file_path):
     """
     Read and parse the custom CSV file format with Type/Ticker headers.
@@ -214,42 +241,52 @@ def custom_read_csv(file_path):
     
     return df
 
+def _normalize_columns(df):
+    if not isinstance(df.columns, pd.MultiIndex):
+        df.columns = pd.MultiIndex.from_product(
+            [["Price"], df.columns], names=["Type", "Ticker"]
+        )
+    return df
+
+
 def fetch_data(ticker, end_date, start_date="2008-01-01", use_local_data=False):
-    """
-    Fetch historical data for a given ticker, either from local file or yfinance.
-    """
+    """Fetch stock data. Cache: CSV per ticker, delta-only after 30s staleness."""
     local_file = f"{ticker}_data.csv"
 
-    if use_local_data and os.path.exists(local_file):
-        trace_event("fetch_data.local_file", ticker=ticker, path=local_file)
-        df = custom_read_csv(local_file)
-        print(f"Loaded data from local file: {local_file}")
-    else:
-        # Fetch data from yfinance
-        trace_event(
-            "fetch_data.remote_start",
-            ticker=ticker,
-            start_date=str(start_date),
-            end_date=str(end_date),
-        )
-        df = _download_with_retry(ticker, start_date, end_date)
-        
-        # Create MultiIndex columns if not already present
-        if not isinstance(df.columns, pd.MultiIndex):
-            df.columns = pd.MultiIndex.from_product(
-                [['Price'], df.columns],
-                names=['Type', 'Ticker']
-            )
-        
-        # Save to CSV with custom format
-        if not df.empty:
-            # Prepare the DataFrame for saving
-            df_to_save = df.copy()
-            df_to_save.index.name = 'Date'
-            df_to_save.to_csv(local_file)
-            trace_event("fetch_data.remote_saved", ticker=ticker, path=local_file, rows=len(df))
-        else:
-            trace_event("fetch_data.remote_empty", ticker=ticker)
-            raise ValueError(f"No data retrieved for ticker {ticker} from yfinance")
+    if os.path.exists(local_file):
+        file_age = time.time() - os.path.getmtime(local_file)
+        if file_age < _CACHE_FRESH_SECONDS:
+            trace_event("fetch_data.cache_hit", ticker=ticker, age_s=round(file_age, 1))
+            return custom_read_csv(local_file)
 
+        # Stale — delta fetch since last row date
+        df = custom_read_csv(local_file)
+        last_date = df.index[-1]
+        delta_start = (last_date + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+        trace_event("fetch_data.delta_start", ticker=ticker, delta_start=delta_start)
+        delta_df = _download_with_retry(ticker, delta_start, end_date)
+        if not delta_df.empty:
+            delta_df = _normalize_columns(delta_df)
+            df = pd.concat([df, delta_df])
+            df = df[~df.index.duplicated(keep="last")]
+            df.index.name = "Date"
+            df.to_csv(local_file)
+            trace_event("fetch_data.delta_saved", ticker=ticker, new_rows=len(delta_df))
+        else:
+            trace_event("fetch_data.delta_empty", ticker=ticker)
+        _record_known_ticker(ticker)
+        return df
+
+    # No cache — full fetch
+    trace_event("fetch_data.full_start", ticker=ticker, start_date=str(start_date), end_date=str(end_date))
+    df = _download_with_retry(ticker, start_date, end_date)
+    df = _normalize_columns(df)
+    if not df.empty:
+        df.index.name = "Date"
+        df.to_csv(local_file)
+        trace_event("fetch_data.full_saved", ticker=ticker, path=local_file, rows=len(df))
+        _record_known_ticker(ticker)
+    else:
+        trace_event("fetch_data.full_empty", ticker=ticker)
+        raise ValueError(f"No data retrieved for ticker {ticker} from yfinance")
     return df

--- a/model.py
+++ b/model.py
@@ -1,10 +1,15 @@
 import numpy as np
 import pandas as pd
+from datetime import date
+from pathlib import Path
 from sklearn.model_selection import train_test_split, cross_val_score, TimeSeriesSplit
 from sklearn.linear_model import LinearRegression
 from sklearn.preprocessing import StandardScaler
 import xgboost as xgb
+import joblib
 from feature_engineering import get_feature_columns
+
+_MODELS_DIR = Path("models")
 
 
 def train_model(
@@ -24,11 +29,16 @@ def train_model(
         y_val (pd.Series): Validation target (optional)
         target (str): 'today' or 'next_day' - determines which close price to predict
     """
-    print(f"\nTraining {model_type} model for {target}'s close")
-
-    # Get ticker from data columns
-    ticker_level = 1  # Index of ticker in MultiIndex
+    ticker_level = 1
     current_ticker = train_ready_data.columns[0][ticker_level]
+
+    model_path = _MODELS_DIR / f"{current_ticker}_{date.today()}_{model_type}_{target}.pkl"
+    if model_path.exists():
+        model, scalers = joblib.load(model_path)
+        print(f"Loaded cached model: {model_path.name}")
+        return model, scalers
+
+    print(f"\nTraining {model_type} model for {target}'s close")
     print(f"Training model for ticker: {current_ticker}")
 
     # Get features with target parameter
@@ -126,7 +136,11 @@ def train_model(
         print("\nLowest importance features:")
         print(importance.tail())
 
-    return model, (X_scaler, y_scaler)
+    scalers = (X_scaler, y_scaler)
+    _MODELS_DIR.mkdir(exist_ok=True)
+    joblib.dump((model, scalers), model_path)
+    print(f"Saved model: {model_path.name}")
+    return model, scalers
 
 
 def feature_importance(model, X):

--- a/model.py
+++ b/model.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-from datetime import date
 from pathlib import Path
 from sklearn.model_selection import train_test_split, cross_val_score, TimeSeriesSplit
 from sklearn.linear_model import LinearRegression
@@ -32,7 +31,8 @@ def train_model(
     ticker_level = 1
     current_ticker = train_ready_data.columns[0][ticker_level]
 
-    model_path = _MODELS_DIR / f"{current_ticker}_{date.today()}_{model_type}_{target}.pkl"
+    last_data_date = train_ready_data.index[-1].strftime("%Y-%m-%d")
+    model_path = _MODELS_DIR / f"{current_ticker}_{last_data_date}_{model_type}_{target}.pkl"
     if model_path.exists():
         model, scalers = joblib.load(model_path)
         print(f"Loaded cached model: {model_path.name}")

--- a/model.py
+++ b/model.py
@@ -34,9 +34,13 @@ def train_model(
     last_data_date = train_ready_data.index[-1].strftime("%Y-%m-%d")
     model_path = _MODELS_DIR / f"{current_ticker}_{last_data_date}_{model_type}_{target}.pkl"
     if model_path.exists():
-        model, scalers = joblib.load(model_path)
-        print(f"Loaded cached model: {model_path.name}")
-        return model, scalers
+        try:
+            model, scalers = joblib.load(model_path)
+            print(f"Loaded cached model: {model_path.name}")
+            return model, scalers
+        except Exception as exc:
+            print(f"Cached model load failed ({exc}), retraining")
+            model_path.unlink(missing_ok=True)
 
     print(f"\nTraining {model_type} model for {target}'s close")
     print(f"Training model for ticker: {current_ticker}")

--- a/render_helpers.py
+++ b/render_helpers.py
@@ -4,6 +4,10 @@ import streamlit as st
 import streamlit.components.v1 as components
 from utils import market_status
 from trace_utils import trace_event
+from data_handler import (
+    YFINANCE_PROVIDER_DOWN_MESSAGE,
+    is_yfinance_provider_down,
+)
 
 
 THEME = {
@@ -59,11 +63,11 @@ THEME = {
     },
 }
 
-YFINANCE_PROVIDER_DOWN_MESSAGE = "yfinance data provider is down, please try later"
 _YFINANCE_PROVIDER_ERROR_MARKERS = (
     "try after a while",
     "failed download",
     "yfr",
+    "yfratelimiterror",
     "rate limit",
     "rate-limit",
     "too many requests",
@@ -422,7 +426,7 @@ def validate_ticker_with_yfinance(ticker):
     except Exception as exc:
         error_text = f"{type(exc).__name__}: {exc}"
         trace_event("search.validation_exception", ticker=ticker, error=error_text)
-        return False, _is_yfinance_provider_failure(error_text)
+        return False, is_yfinance_provider_down(ticker, exc)
 
     shared_error = _yfinance_shared_error(ticker)
     if shared_error:
@@ -431,7 +435,7 @@ def validate_ticker_with_yfinance(ticker):
     if data is not None and not getattr(data, "empty", True):
         return True, False
 
-    return False, _is_yfinance_provider_failure(shared_error)
+    return False, is_yfinance_provider_down(ticker) or _is_yfinance_provider_failure(shared_error)
 
 
 def ticker_header_html(ticker, theme_name=None):

--- a/tests/test_search_validation.py
+++ b/tests/test_search_validation.py
@@ -47,10 +47,21 @@ def test_validate_ticker_reports_provider_down_from_exception(monkeypatch):
     assert render_helpers.validate_ticker_with_yfinance("TSLA") == (False, True)
 
 
+def test_validate_ticker_reports_provider_down_from_yfinance_rate_limit_exception(monkeypatch):
+    YFRateLimitError = type("YFRateLimitError", (Exception,), {})
+
+    def fake_download(*args, **kwargs):
+        raise YFRateLimitError("Too Many Requests")
+
+    monkeypatch.setattr(render_helpers.yf, "download", fake_download)
+
+    assert render_helpers.validate_ticker_with_yfinance("TSLA") == (False, True)
+
+
 def test_provider_down_message_text_is_stable():
     assert (
         render_helpers.YFINANCE_PROVIDER_DOWN_MESSAGE
-        == "yfinance data provider is down, please try later"
+        == "Data Provider yfinance is currently down. Please try again later."
     )
 
 

--- a/tests/test_yfinance_provider_status.py
+++ b/tests/test_yfinance_provider_status.py
@@ -7,6 +7,13 @@ def test_provider_down_detects_try_after_exception():
     assert data_handler.is_yfinance_provider_down("TSLA", exc)
 
 
+def test_provider_down_detects_yfinance_rate_limit_exception_type():
+    YFRateLimitError = type("YFRateLimitError", (Exception,), {})
+    exc = YFRateLimitError("Too Many Requests")
+
+    assert data_handler.is_yfinance_provider_down("TSLA", exc)
+
+
 def test_provider_down_detects_shared_yfinance_error(monkeypatch):
     monkeypatch.setattr(
         data_handler.yf_shared,
@@ -28,5 +35,5 @@ def test_provider_down_ignores_plain_invalid_ticker_error(monkeypatch):
 def test_provider_down_message_text_is_stable():
     assert (
         data_handler.YFINANCE_PROVIDER_DOWN_MESSAGE
-        == "yfinance data provider is down, please try later"
+        == "Data Provider yfinance is currently down. Please try again later."
     )


### PR DESCRIPTION
## Summary
- `fetch_data()` now caches per-ticker CSV; checks file mtime — if < 30s returns as-is, else delta-fetches only missing closes and appends (historical rows immutable)
- `train_model()` saves trained model + scalers to `models/{ticker}_{last_data_date}_{model_type}_{target}.pkl` via joblib; cache hit when no new closes exist, retrain only when CSV gains new rows
- `known_tickers.json` written after first successful fetch; `is_known_ticker()` available for callers
- `models/` and `known_tickers.json` added to `.gitignore`

## Test plan
- [ ] First Predict on ticker: fetches full history, writes CSV, trains all 4 models, writes pkls
- [ ] Second Predict (< 30s): CSV returned as-is, pkls loaded, no yfinance call, no retrain
- [ ] Predict after new trading close appears: delta row appended, models retrained with new data
- [ ] `known_tickers.json` written after first successful fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)