### PR TITLE
[codex] fix yfinance rate limit outage message

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -18,12 +18,13 @@ _YF_RETRY_ERROR_MARKERS = (
     "try after a while",
     "failed download",
     "yfr",
+    "yfratelimiterror",
     "runtimeerror",
     "rate limit",
     "rate-limit",
     "too many requests",
 )
-YFINANCE_PROVIDER_DOWN_MESSAGE = "yfinance data provider is down, please try later"
+YFINANCE_PROVIDER_DOWN_MESSAGE = "Data Provider yfinance is currently down. Please try again later."
 
 
 def _default_yfinance_cache_dir():

--- a/render_helpers.py
+++ b/render_helpers.py
@@ -4,6 +4,10 @@ import streamlit as st
 import streamlit.components.v1 as components
 from utils import market_status
 from trace_utils import trace_event
+from data_handler import (
+    YFINANCE_PROVIDER_DOWN_MESSAGE,
+    is_yfinance_provider_down,
+)
 
 
 THEME = {
@@ -59,11 +63,11 @@ THEME = {
     },
 }
 
-YFINANCE_PROVIDER_DOWN_MESSAGE = "yfinance data provider is down, please try later"
 _YFINANCE_PROVIDER_ERROR_MARKERS = (
     "try after a while",
     "failed download",
     "yfr",
+    "yfratelimiterror",
     "rate limit",
     "rate-limit",
     "too many requests",
@@ -422,7 +426,7 @@ def validate_ticker_with_yfinance(ticker):
     except Exception as exc:
         error_text = f"{type(exc).__name__}: {exc}"
         trace_event("search.validation_exception", ticker=ticker, error=error_text)
-        return False, _is_yfinance_provider_failure(error_text)
+        return False, is_yfinance_provider_down(ticker, exc)
 
     shared_error = _yfinance_shared_error(ticker)
     if shared_error:
@@ -431,7 +435,7 @@ def validate_ticker_with_yfinance(ticker):
     if data is not None and not getattr(data, "empty", True):
         return True, False
 
-    return False, _is_yfinance_provider_failure(shared_error)
+    return False, is_yfinance_provider_down(ticker) or _is_yfinance_provider_failure(shared_error)
 
 
 def ticker_header_html(ticker, theme_name=None):

--- a/tests/test_search_validation.py
+++ b/tests/test_search_validation.py
@@ -47,10 +47,21 @@ def test_validate_ticker_reports_provider_down_from_exception(monkeypatch):
     assert render_helpers.validate_ticker_with_yfinance("TSLA") == (False, True)
 
 
+def test_validate_ticker_reports_provider_down_from_yfinance_rate_limit_exception(monkeypatch):
+    YFRateLimitError = type("YFRateLimitError", (Exception,), {})
+
+    def fake_download(*args, **kwargs):
+        raise YFRateLimitError("Too Many Requests")
+
+    monkeypatch.setattr(render_helpers.yf, "download", fake_download)
+
+    assert render_helpers.validate_ticker_with_yfinance("TSLA") == (False, True)
+
+
 def test_provider_down_message_text_is_stable():
     assert (
         render_helpers.YFINANCE_PROVIDER_DOWN_MESSAGE
-        == "yfinance data provider is down, please try later"
+        == "Data Provider yfinance is currently down. Please try again later."
     )
 
 

--- a/tests/test_yfinance_provider_status.py
+++ b/tests/test_yfinance_provider_status.py
@@ -7,6 +7,13 @@ def test_provider_down_detects_try_after_exception():
     assert data_handler.is_yfinance_provider_down("TSLA", exc)
 
 
+def test_provider_down_detects_yfinance_rate_limit_exception_type():
+    YFRateLimitError = type("YFRateLimitError", (Exception,), {})
+    exc = YFRateLimitError("Too Many Requests")
+
+    assert data_handler.is_yfinance_provider_down("TSLA", exc)
+
+
 def test_provider_down_detects_shared_yfinance_error(monkeypatch):
     monkeypatch.setattr(
         data_handler.yf_shared,
@@ -28,5 +35,5 @@ def test_provider_down_ignores_plain_invalid_ticker_error(monkeypatch):
 def test_provider_down_message_text_is_stable():
     assert (
         data_handler.YFINANCE_PROVIDER_DOWN_MESSAGE
-        == "yfinance data provider is down, please try later"
+        == "Data Provider yfinance is currently down. Please try again later."
     )


### PR DESCRIPTION
## What changed
- Detect yfinance `YFRateLimitError` by exception type/name as a provider outage.
- Show the customer-facing message: `Data Provider yfinance is currently down. Please try again later.`
- Centralize the Streamlit provider-down copy through `data_handler` and add tests for the exception path.

## Why
When yfinance rate-limits or has a provider-side outage, customers should see a clear data-provider message instead of a raw exception or generic failure.

## Validation
- `python -m pytest` - 111 passed
