### PR TITLE
feat: next-day section header shows 'Next Trading Day's Close Predictions <Date>'

### DIFF
--- a/display_market_status.py
+++ b/display_market_status.py
@@ -64,7 +64,7 @@ def generate_next_day_header(next_date_str):
     is the concrete next trading session (utils.next_trading_day of the last
     completed session) — before the bell this is today.
     """
-    return f"Predictions for {next_date_str}"
+    return f"Next Trading Day's Close Predictions {next_date_str}"
 
 
 def display_market_status(last_available_date):

--- a/display_market_status.py
+++ b/display_market_status.py
@@ -64,7 +64,7 @@ def generate_next_day_header(next_date_str):
     is the concrete next trading session (utils.next_trading_day of the last
     completed session) — before the bell this is today.
     """
-    return f"Next Trading Day's Close Predictions {next_date_str}"
+    return f"Next Day's Close Predictions {next_date_str}"
 
 
 def display_market_status(last_available_date):

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -85,7 +85,7 @@ def test_unknown_status_raises():
 def test_next_day_header_is_forward_no_displaying_cue():
     # forward section never uses the "Displaying" past-session cue
     html = generate_next_day_header("Monday, June 15")
-    assert html == "Predictions for Monday, June 15"
+    assert html == "Next Trading Day's Close Predictions Monday, June 15"
     assert "Displaying" not in html
 
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -85,7 +85,7 @@ def test_unknown_status_raises():
 def test_next_day_header_is_forward_no_displaying_cue():
     # forward section never uses the "Displaying" past-session cue
     html = generate_next_day_header("Monday, June 15")
-    assert html == "Next Trading Day's Close Predictions Monday, June 15"
+    assert html == "Next Day's Close Predictions Monday, June 15"
     assert "Displaying" not in html
 
 


### PR DESCRIPTION
## Summary
- `generate_next_day_header()` now returns `"Next Trading Day's Close Predictions {date}"` instead of `"Predictions for {date}"`
- Updated matching assertion in `tests/test_header.py`

## Test plan
- [ ] Predict on any ticker — next-day section header reads "Next Trading Day's Close Predictions Tuesday, June 17" (or whatever the next session date is)
- [ ] Fallback path ("the next session") renders correctly when next session date unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)