### PR TITLE
feat: multiselect label hints click-away to apply

### DIFF
--- a/render_ui.py
+++ b/render_ui.py
@@ -258,7 +258,7 @@ def render_ui():
         st.warning(f"Maximum {UI_RULES['max_tickers']} tickers can be selected")
 
     tickers = st.multiselect(
-        "Choose stocks to predict (click away to apply):",
+        "Choose multiple stocks to predict...",
         valid_tickers,
         default=selected_tickers,
         key=widget_key,

--- a/render_ui.py
+++ b/render_ui.py
@@ -258,7 +258,7 @@ def render_ui():
         st.warning(f"Maximum {UI_RULES['max_tickers']} tickers can be selected")
 
     tickers = st.multiselect(
-        "Select stocks to predict:",
+        "Choose stocks to predict (click away to apply):",
         valid_tickers,
         default=selected_tickers,
         key=widget_key,


### PR DESCRIPTION
## Summary
- Changed multiselect label from `"Select stocks to predict:"` to `"Choose stocks to predict (click away to apply):"` so users know to click outside the dropdown to confirm selection

## Test plan
- [ ] Open app, multiselect shows updated label with click-away hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)