### PR TITLE
fix: cache CSV round-trip (KeyError: 'Date') + dark scrollbar & multiselect copy

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -217,29 +217,32 @@ def is_known_ticker(ticker):
 
 def custom_read_csv(file_path):
     """
-    Read and parse the custom CSV file format with Type/Ticker headers.
+    Read a cached CSV written by ``df.to_csv`` from a frame with MultiIndex
+    (Type, Ticker) columns and a ``Date`` index.
+
+    On disk that looks like::
+
+        Price,Close,High,Low,Open,Volume   <- row 0: Type
+        Ticker,AAPL,AAPL,AAPL,AAPL,AAPL     <- row 1: Ticker
+        Date,,,,,                           <- row 2: leftover index-name row
+        2008-01-02,5.83,...                 <- data
+
+    So we read the two header rows as a MultiIndex, take column 0 as the
+    index, drop the stray ``Date`` index-name row, and coerce the index to
+    datetime.
     """
-    # Read the entire file
-    df = pd.read_csv(file_path)
-    
-    # Extract the column types and ticker info
-    types = df.iloc[0]  # First row contains Types
-    tickers = df.iloc[1]  # Second row contains Tickers
-    
-    # Remove the Type and Ticker rows and reset the index
-    df = df.iloc[2:].reset_index(drop=True)
-    
-    # Convert Date column to datetime and set as index
-    df['Date'] = pd.to_datetime(df['Date'])
-    df.set_index('Date', inplace=True)
-    
-    # Create MultiIndex columns
-    columns = pd.MultiIndex.from_arrays(
-        [types[1:].values, tickers[1:].values],
-        names=['Type', 'Ticker']
-    )
-    df.columns = columns
-    
+    df = pd.read_csv(file_path, header=[0, 1], index_col=0)
+    df.columns.names = ['Type', 'Ticker']
+
+    # Row 2 ("Date,,,,,") survives as an index label of "Date"; drop it.
+    df = df[df.index.astype(str) != 'Date']
+
+    df.index = pd.to_datetime(df.index)
+    df.index.name = 'Date'
+
+    # Numeric columns come back as object after the header gymnastics.
+    df = df.apply(pd.to_numeric, errors='coerce')
+
     return df
 
 def _normalize_columns(df):

--- a/data_handler.py
+++ b/data_handler.py
@@ -230,18 +230,36 @@ def custom_read_csv(file_path):
     So we read the two header rows as a MultiIndex, take column 0 as the
     index, drop the stray ``Date`` index-name row, and coerce the index to
     datetime.
+
+    A truncated or otherwise corrupt cache file (e.g. a crash mid-write)
+    must not silently poison predictions: any parse failure, an unparseable
+    index, or an all-NaN value section is treated as corruption and returns
+    an empty DataFrame so the caller's ``df.empty`` branch removes the file
+    and re-fetches.
     """
-    df = pd.read_csv(file_path, header=[0, 1], index_col=0)
+    try:
+        df = pd.read_csv(file_path, header=[0, 1], index_col=0)
+    except (pd.errors.EmptyDataError, pd.errors.ParserError):
+        return pd.DataFrame()
+
     df.columns.names = ['Type', 'Ticker']
 
     # Row 2 ("Date,,,,,") survives as an index label of "Date"; drop it.
     df = df[df.index.astype(str) != 'Date']
 
-    df.index = pd.to_datetime(df.index)
+    # Coerce index to dates; an unparseable row becomes NaT and is dropped
+    # rather than raising into the Streamlit render loop.
+    df.index = pd.to_datetime(df.index, errors='coerce')
+    df = df[df.index.notna()]
     df.index.name = 'Date'
 
     # Numeric columns come back as object after the header gymnastics.
     df = df.apply(pd.to_numeric, errors='coerce')
+
+    # An all-NaN value section means the file was truncated or garbled;
+    # treat it as corrupt so the caller removes and re-fetches it.
+    if not df.empty and df.isnull().all(axis=None):
+        return pd.DataFrame()
 
     return df
 

--- a/render_ui.py
+++ b/render_ui.py
@@ -205,6 +205,36 @@ def update_selected_tickers(change):
     print(f"[AFTER MULTISELECT] Multiselect value: {st.session_state.selected_tickers}")
 
 
+def app_scrollbar_css():
+    return """
+    <style>
+      html {
+        scrollbar-width: thin;
+        scrollbar-color: #475569 #0f172a;
+      }
+
+      ::-webkit-scrollbar {
+        width: 10px;
+        height: 10px;
+      }
+
+      ::-webkit-scrollbar-track {
+        background: #0f172a;
+      }
+
+      ::-webkit-scrollbar-thumb {
+        background: #475569;
+        border: 2px solid #0f172a;
+        border-radius: 999px;
+      }
+
+      ::-webkit-scrollbar-thumb:hover {
+        background: #64748b;
+      }
+    </style>
+    """
+
+
 def render_ui():
     trace_event(
         "render_ui.enter",
@@ -213,6 +243,7 @@ def render_ui():
         new_ticker=st.session_state.get("new_ticker"),
         run_prediction=st.session_state.get("run_prediction"),
     )
+    st.markdown(app_scrollbar_css(), unsafe_allow_html=True)
     st.title("Stock Price Predictor")
 
     # Initialize default tickers if not already in session state
@@ -258,14 +289,14 @@ def render_ui():
         st.warning(f"Maximum {UI_RULES['max_tickers']} tickers can be selected")
 
     tickers = st.multiselect(
-        "Choose multiple stocks to predict...",
+        "Choose multiple stocks:",
         valid_tickers,
         default=selected_tickers,
         key=widget_key,
         on_change=update_selected_tickers,
         args=[widget_key],
         max_selections=UI_RULES["max_tickers"],
-        placeholder="Choose from the list or search below (e.g. TSLA, AAPL, GOOGL...)",
+        placeholder="Choose multiple stocks... (e.g. TSLA, AAPL, GOOGL...)",
     )
 
     # Update selected tickers based on multiselect

--- a/tests/test_customer_facing_ui.py
+++ b/tests/test_customer_facing_ui.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from render_ui import app_scrollbar_css
+
 
 def test_cache_debug_controls_are_not_customer_facing():
     source = Path("render_ui.py").read_text(encoding="utf-8")
@@ -7,3 +9,12 @@ def test_cache_debug_controls_are_not_customer_facing():
     assert "Cache Debug" not in source
     assert "Show yfinance cache path" not in source
     assert "Clear yfinance cache now" not in source
+
+
+def test_app_scrollbar_css_uses_dark_theme_styling():
+    css = app_scrollbar_css()
+
+    assert "scrollbar-width: thin" in css
+    assert "scrollbar-color: #475569 #0f172a" in css
+    assert "::-webkit-scrollbar-thumb" in css
+    assert "border-radius: 999px" in css

--- a/tests/test_customer_facing_ui.py
+++ b/tests/test_customer_facing_ui.py
@@ -11,10 +11,10 @@ def test_cache_debug_controls_are_not_customer_facing():
     assert "Clear yfinance cache now" not in source
 
 
-def test_app_scrollbar_css_uses_dark_theme_styling():
+def test_app_scrollbar_css_is_well_formed_dark_styling():
     css = app_scrollbar_css()
 
+    # Structural, not value-coupled: a palette/token tweak shouldn't break this.
+    assert "<style>" in css and "</style>" in css
     assert "scrollbar-width: thin" in css
-    assert "scrollbar-color: #475569 #0f172a" in css
     assert "::-webkit-scrollbar-thumb" in css
-    assert "border-radius: 999px" in css

--- a/tests/test_data_handler_cache.py
+++ b/tests/test_data_handler_cache.py
@@ -1,0 +1,66 @@
+"""Round-trip and corruption tests for the cache CSV reader.
+
+custom_read_csv must read back exactly what fetch_data writes via df.to_csv
+(MultiIndex (Type, Ticker) columns + a Date index). The production bug this
+guards against was KeyError: 'Date' — the reader assuming a literal Date
+column the writer never emits.
+"""
+
+import numpy as np
+import pandas as pd
+
+from data_handler import custom_read_csv
+
+
+def _make_frame():
+    """A frame shaped exactly like what fetch_data caches."""
+    index = pd.to_datetime(["2008-01-02", "2008-01-03", "2008-01-04"])
+    index.name = "Date"
+    columns = pd.MultiIndex.from_product(
+        [["Close", "High", "Low", "Open", "Volume"], ["TSLA"]],
+        names=["Type", "Ticker"],
+    )
+    data = np.arange(15, dtype=float).reshape(3, 5)
+    return pd.DataFrame(data, index=index, columns=columns)
+
+
+def test_round_trips_multiindex_cache(tmp_path):
+    path = tmp_path / "TSLA_data.csv"
+    _make_frame().to_csv(path)
+
+    df = custom_read_csv(path)
+
+    assert isinstance(df.index, pd.DatetimeIndex)
+    assert df.index.name == "Date"
+    assert df.index[-1] == pd.Timestamp("2008-01-04")  # delta path relies on this
+    assert isinstance(df.columns, pd.MultiIndex)
+    assert df.columns.names == ["Type", "Ticker"]
+    assert all(np.issubdtype(dt, np.number) for dt in df.dtypes)
+    assert df.shape == (3, 5)
+
+
+def test_empty_file_is_treated_as_corrupt(tmp_path):
+    path = tmp_path / "EMPTY_data.csv"
+    path.write_text("", encoding="utf-8")
+
+    # Must not raise — returns empty so fetch_data removes and re-fetches.
+    assert custom_read_csv(path).empty
+
+
+def test_header_only_file_is_empty(tmp_path):
+    path = tmp_path / "HDR_data.csv"
+    # Two header rows + stray Date row, no data — a crash before any row landed.
+    path.write_text("Price,Close\nTicker,TSLA\nDate,\n", encoding="utf-8")
+
+    assert custom_read_csv(path).empty
+
+
+def test_all_nan_value_section_is_treated_as_corrupt(tmp_path):
+    path = tmp_path / "NAN_data.csv"
+    path.write_text(
+        "Price,Close\nTicker,TSLA\nDate,\n2008-01-02,garbage\n2008-01-03,more\n",
+        encoding="utf-8",
+    )
+
+    # Every value coerces to NaN -> corrupt -> empty, so the file gets removed.
+    assert custom_read_csv(path).empty


### PR DESCRIPTION
Two changes.

## 1. fix: cache CSV reader round-trips MultiIndex format (production bug)

Production skipped every ticker with `KeyError: 'Date'`:

```
File "pipeline.py", line 67, in execute_pipeline
  stock_data = fetch_data(ticker, nyse_date + timedelta(days=2))
File "data_handler.py", line 233, in custom_read_csv
  df['Date'] = pd.to_datetime(df['Date'])
KeyError: 'Date'
```

**Root cause:** the #31 delta cache writes `*_data.csv` via `df.to_csv` from a
frame with MultiIndex `(Type, Ticker)` columns and a `Date` index — two header
rows plus a stray `Date,,,` row. `custom_read_csv` still assumed the old 3-row
layout with a literal `Date` **column**, so the reader and writer were never
round-trip compatible.

**Fix:** parse what the writer emits — `header=[0,1]` MultiIndex columns,
`index_col=0`, drop the stray `Date` index row, coerce index to datetime and
columns to numeric.

## 2. feat: dark scrollbar + clearer multiselect copy

`app_scrollbar_css()` injects a thin dark scrollbar matching the dark UI.
Multiselect label simplified to `Choose multiple stocks:`.

## Verification

- Round-trip unit check on real `AAPL_data.csv`: correct shape, DatetimeIndex
  named `Date`, numeric dtypes, `df.index[-1]` valid.
- `fetch_data` end-to-end: cache read → delta fetch → return, no error.
- Manual UI test (Playwright, local): Predict TSLA → `Predictions ready for
  TSLA`, full predictions + chart, **0 console errors**, no ticker skip.
- Scrollbar CSS + new multiselect label confirmed injected/rendered live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)