### PR TITLE
chore: agentic dev-loop scaffolding (dev-workflow skill + loop prompt)

### DIFF
--- a/.claude/agentic-loop.json
+++ b/.claude/agentic-loop.json
@@ -1,0 +1,26 @@
+{
+  "name": "stockpredictors-prod-ticker-loop",
+  "version": "1.0",
+  "goal": "Keep prod (stockpredictors.onrender.com) able to predict any selected ticker. Each iteration: find the live failure, fix it, ship it, verify it. Stop only when the ticker works or genuinely stuck.",
+  "skill": "dev-workflow",
+  "mandate": "full-auto: branch+worktree -> fix -> local-gate -> PR -> self-review -> merge -> deploy -> browser-verify -> loop. Do not pause for merge/deploy approval.",
+  "refs": {
+    "render_cli": "/mnt/c/Users/User/.local/bin/render-cli/cli_v2.20.0.exe",
+    "service_id": "srv-csvanmqj1k6c73c3dnt0",
+    "prod_url": "https://stockpredictors.onrender.com",
+    "test_python": "/mnt/c/Users/User/StockPredictors/venv/Scripts/python.exe",
+    "repo": "/mnt/c/Users/User/StockPredictors"
+  },
+  "loop": [
+    {"step": "observe", "do": "deploys list (confirm live commit; prod is MANUAL-deploy and lags main) + logs --limit 200; grep pipeline.ticker_exception / error_type for the real failure. Reproduce in browser if no log error."},
+    {"step": "diagnose", "do": "Map error to code via graphify-out + traceback. Rate-limit markers (Try after a while / YFR / Failed download) = account/IP throttle: clear /opt/render/.cache/py-yfinance and retest BEFORE assuming a code bug."},
+    {"step": "fix", "do": "git worktree add sibling branch off main; minimal targeted fix; add/extend a regression test."},
+    {"step": "gate", "do": "Windows venv python -m pytest -q in the worktree; must be green (baseline 116)."},
+    {"step": "ship", "do": "gh pr create -> self-review comment w/ root cause + evidence -> gh pr merge --merge --delete-branch -> remove worktree, prune branch, sync main."},
+    {"step": "deploy", "do": "deploys create --confirm; background-poll deploys list until status=live (~3-5min, no foreground sleep)."},
+    {"step": "verify", "do": "Browser: open prod, select the failing ticker, Predict, wait (model retrains, slow), confirm cards render + 0 skipped. Re-pull logs to confirm no exception."}
+  ],
+  "done_when": "Target ticker(s) render predictions on prod with no skipped/KeyError in logs.",
+  "escalate_when": "Same fix fails twice, deploy fails to build, rate-limit persists after cache clear, or a change would touch access-control / prod data / secrets. Surface to user with evidence; do not retry blindly.",
+  "guardrails": ["never force-push main", "never auto-delete prod data", "don't commit *_data.csv / models/ / known_tickers.json", "one logical change per PR"]
+}

--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: dev-workflow
+description: StockPredictors fix/ship cycle — branch+worktree per change, local-gate tests, PR→review→merge→clean, Render deploy + browser-verify prod. Use when fixing a bug, shipping a change, or running the autonomous prod-debug loop.
+---
+
+# dev-workflow
+
+Isolated, rollback-friendly cycle for every change. One change = one branch = one worktree = one PR.
+
+## 0. Baseline (session start)
+```bash
+git fetch origin --quiet
+git switch -c chore/$(date +%F)-<topic> main   # branch off production-parity main
+```
+
+## 1. Branch + worktree per fix
+```bash
+git worktree add /mnt/c/Users/User/StockPredictors-<branch> -b <branch> main
+```
+Sibling dir naming `StockPredictors-<branch>` matches CLAUDE.md. Worktree = isolation; rollback = just delete it.
+
+## 2. Local gate (MUST pass before PR)
+```bash
+cd /mnt/c/Users/User/StockPredictors-<branch> && \
+  /mnt/c/Users/User/StockPredictors/venv/Scripts/python.exe -m pytest -q
+```
+Use the **Windows venv python** — system python3 lacks app deps (pandas_market_calendars, streamlit). Baseline = 116 passed. Bash cwd resets each call, so `cd` in the same command.
+
+## 3. PR → review → merge → clean
+```bash
+gh pr create --base main --head <branch> --title "..." --body "<root cause + test evidence>"
+gh pr view <n> --json mergeable,mergeStateStatus   # expect MERGEABLE / CLEAN
+gh pr comment <n> --body "<self-review: evidence>"
+gh pr merge <n> --merge --delete-branch            # --merge keeps commits for cherry-pick
+```
+Worktree blocks local branch delete → remove it first, then prune:
+```bash
+git worktree remove /mnt/c/Users/User/StockPredictors-<branch> --force
+git branch -D <branch>; git branch -f main origin/main
+```
+
+## 4. Deploy (Render = MANUAL, prod lags main)
+```bash
+CLI=/mnt/c/Users/User/.local/bin/render-cli/cli_v2.20.0.exe   # runs from WSL, pre-authed
+SRV=srv-csvanmqj1k6c73c3dnt0
+$CLI deploys list $SRV --output json    # check live commit FIRST (top status=live)
+$CLI deploys create $SRV --confirm --output json
+```
+Poll `deploys list` until top `status=live` (~3-5 min). Run the poll in **background** (no foreground sleep).
+
+## 5. Verify on prod
+Logs: `$CLI logs --resources $SRV --limit 200 --output text` → grep `pipeline.ticker_exception`.
+Browser (claude-in-chrome): open https://stockpredictors.onrender.com → select ticker → Predict →
+wait (model retrains, slow) → confirm cards render, no skipped tickers / KeyError.
+
+Rate-limit markers (`Try after a while`, `YFR`, `Failed download`) = account/IP throttle, not code.
+Clear yfinance cache (`/opt/render/.cache/py-yfinance`) and retest.
+
+## Rules
+- Never force-push `main`. Never auto-delete prod data.
+- Don't check in historical stock data (`*_data.csv`, `models/`, `known_tickers.json` are gitignored).
+- One logical change per PR; PR body states root cause + test evidence.

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,10 @@ models/
 
 # Known tickers list (regenerated at runtime)
 known_tickers.json
+
+# Agent / tooling scratch output (regenerated, not source)
+graphify-out/
+.graphifyignore
+.playwright-mcp/
+.gemini/
+.kiro/


### PR DESCRIPTION
Durable scaffolding for the autonomous prod-debug loop set up this session.

## What
- **`.claude/skills/dev-workflow/SKILL.md`** — the fix/ship cycle: branch+worktree per change → local-gate (Windows venv `pytest`) → PR → review → merge → clean → Render deploy → browser-verify prod. Encodes the env gotchas (system python3 lacks app deps; Render deploys are *manual* and lag `main`).
- **`.claude/agentic-loop.json`** — optimized structured loop prompt (observe→diagnose→fix→gate→ship→deploy→verify) with refs, done/escalation criteria, guardrails.
- **`.gitignore`** — ignore regenerated agent/tooling scratch (`graphify-out/`, `.playwright-mcp/`, etc).

## Context
Created alongside the cache-CSV `KeyError: 'Date'` fix (#35), which is now merged + deployed + verified green on prod (GOOGL predicts; `skipped_tickers=[]`).

No app code touched. Docs/config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)