### PR TITLE
docs: handoff carousel state + verified prod cache fix

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,9 +1,10 @@
-# HANDOFF — StockPredictors
-Updated: 2026-06-17 | Branch: `main` @ `3404a86`
+# HANDOFF — StockPredictors + Carousel Project
+Updated: 2026-06-24 | Branch: `main` @ `42db1dc` (cache fix merged) | Carousel: complete
 
 ## Workspace
 - Path: `c:\Users\User\StockPredictors`
-- Production: `https://stockpredictors.onrender.com` (Render `srv-csvanmqj1k6c73c3dnt0`)
+- Production: `https://stockpredictors.onrender.com` (Render `srv-csvanmqj1k6c73c3dnt0`) — LIVE, verified working (GOOGL predictions + chart render)
+- Carousel: `C:\Users\User\StockPredictors-carousel\` — 7-slide LinkedIn deck on agentic loops
 - Secondary worktree: none active
 
 ## Run commands
@@ -55,3 +56,35 @@ $env:MARKET_NOW = ""                    # clear
 - Dark mode default; toggle via `st.session_state.theme`
 - Do not validate ticker with yfinance before selecting — prediction pipeline is source of truth
 - Use `pandas_market_calendars` / XNYS for trading-day checks, not clock time
+
+---
+
+## LinkedIn Carousel Project — NEAR FINAL
+
+**Status:** All 7 slides rendered + PDF assembled (v2), ready to finalize + caption queued.
+
+**Files:** `C:\Users\User\StockPredictors-carousel\`
+- HTML: `slide1.html` – `slide7.html` (with embedded CSS: browser-mockup, trace-table, anatomy-steps, before/after, recap-cards)
+- PNG: `slide1.png` – `slide7.png` (all 2160×2700, retina 2×)
+- PDF: `StockPredictors-agentic-loop-carousel-v2.pdf` (current; original locked)
+
+**Slide layout:**
+1. Hook + app mockup (`stockpredictors.onrender.com` address bar + LIVE badge + real GOOGL $346.42/$356.86 + candlestick chart)
+2. Voice memo (verbatim, trimmed rate-limit line only)
+3. JSON loop spec (juicy bits)
+4. Anatomy — six moves (OBSERVE/FIX/GATE/SHIP/DEPLOY/VERIFY)
+5. **Verify trace** — the intelligence (DECIDE → OPEN → TYPE → CLICK → CHECK → SANITY → RECONCILE, with judgment calls & green checkmarks)
+6. Before/after proof (prod logs showing KeyError 'Date' crash → clean skipped_tickers=[], live predictions)
+7. Takeaway (the four pillars: goal/loop/guardrails/feedback)
+
+**Pending cleanup (next session or before upload):**
+1. Close original `...-carousel.pdf` file (locked on Windows)
+2. Delete `...-carousel-v2.pdf`, rename `slide1-7.png` files if needed, recreate final PDF with original filename
+3. Close 2 browser tabs (both `https://stockpredictors.onrender.com/`)
+
+**LinkedIn caption:** Streamlined version (approved) — NO "things become names" paragraph (that's a separate post). Hooks: broken-app story → build-with-AI motivation → DM invite → "short small pieces of value."
+
+**Asset notes:**
+- Slide 1 app mockup: CSS-built recreation (not raw screenshot) with real live values from 2026-06-23 run
+- All copy matches project voice; theme matches dark-mode Streamlit app
+- PDF built via Pillow (PIL); render process uses headless Chrome 2× DPI


### PR DESCRIPTION
## Summary
Documentation-only update to `HANDOFF.md`.

- Records the 7-slide LinkedIn carousel project: slide layout, render pipeline (headless Chrome 2× → Pillow PDF), caption status, and cleanup TODOs.
- Marks production **verified working** after the `custom_read_csv` cache-roundtrip fix (GOOGL predictions + chart render live).
- Updates branch/commit pointer and workspace notes.

## Scope
- ✅ `HANDOFF.md` only (+36 lines)
- ⛔ Intentionally excludes a local `.claude/settings.json` permission-allowlist edit (machine-local config, not for the shared repo)

## Risk
None — no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)